### PR TITLE
[round-2] 이커머스 도메인 설계

### DIFF
--- a/docs/design/00-ubiquitous-languages.md
+++ b/docs/design/00-ubiquitous-languages.md
@@ -10,4 +10,10 @@
 | 상품 좋아요     | ProductLike      | 유저가 상품에 관심을 표시하는 기능    |
 | 상품 좋아요 여부  | IsProductLiked   | 유저가 상품을 좋아요 했는지 여부     |
 | 총 상품 좋아요 수 | ProductLikeCount | 상품에 대한 총 좋아요 수         |
+| 상품 재고      | ProductStock     | 상품의 구매 가능한 수량          |
+| 주문         | Order            | 유저가 상품을 구매하는 행위        |
+| 주문 상품      | OrderLine        | 주문에 포함된 상품 정보          |
+| 포인트        | Point            | 유저가 결제시에 지불하는 포인트      |
+| 포인트 내역     | PointHistory     | 유저의 포인트 사용 및 충전 내역     |
+
  

--- a/docs/design/03-class-diagrams.md
+++ b/docs/design/03-class-diagrams.md
@@ -2,9 +2,24 @@
 classDiagram
     class Product {
         - Brand brand
-        - String name
         - Price price
+        - Stock stock
+        - String name
         - String description
+        + buy(Quantity quantity)
+    }
+
+    Product "N" --> Brand: 참조
+    Product --> Price: 소유
+    Product --> Stock: 소유
+
+    class Price {
+        - BigInt amount
+    }
+
+    class Stock {
+        - BigInt quantity
+        + subtract(BigInt quantity)
     }
 
     class ProductLike {
@@ -12,20 +27,48 @@ classDiagram
         - User user
     }
 
+    ProductLike "N" --> Product: 참조
+    ProductLike "N" --> User: 참조
+
     class Brand {
         - String name
         - String description
     }
 
-    class Price {
-        - BigInt amount
-    }
-
     class User {
     }
 
-    Product "N" --> Brand: 참조
-    Product --> Price: 소유
-    ProductLike "N" --> Product: 참조
-    ProductLike "N" --> User: 참조
+    class Point {
+        - User user
+        - BigInt amount
+        + pay(BigInt amount)
+        + charge(BigInt amount)
+    }
+
+    Point --> User: 참조
+
+    class PointHistory {
+        - Point point
+        - BigInt amount
+        - BigInt balance
+    }
+
+    PointHistory "N" --> Point: 참조
+
+    class Order {
+        - User user
+        - List<OrderLine> orderLines
+        - BigInt totalPrice
+    }
+
+    Order --> User: 참조
+
+    class OrderLine {
+        - Product product
+        - BigInt quantity
+        - BigInt price
+    }
+
+    Order "N" --> OrderLine: 소유
+    OrderLine --> Product: 참조
 ```

--- a/docs/design/04-erd.md
+++ b/docs/design/04-erd.md
@@ -8,11 +8,21 @@ erDiagram
         string description "상품 설명"
     }
 
+    product ||--o{ productLike: "referenced"
+
     productLike {
         bigint id PK "좋아요 ID"
         bigint ref_product_id FK "상품 ID"
         bigint ref_user_id FK "유저 ID"
     }
+
+    productStock {
+        bigint id PK "재고 ID"
+        bigint ref_product_id FK "상품 ID"
+        bigint quantity "재고 수량"
+    }
+
+    product ||--o| productStock: "referenced"
 
     brand {
         bigint id PK "브랜드 ID"
@@ -20,11 +30,47 @@ erDiagram
         string description "브랜드 설명"
     }
 
+    brand ||--o{ product: "referenced"
+
     user {
         bigint id PK "유저 ID"
     }
 
-    brand ||--o{ product: "referenced"
-    product ||--o{ productLike: "referenced"
     user ||--o{ productLike: "referenced"
+    user ||--o| point: "referenced"
+
+    point {
+        bigint id PK "포인트 ID"
+        bigint ref_user_id FK "유저 ID"
+        bigint balance "포인트 잔액"
+    }
+
+    point ||--o{ pointHistory: "referenced"
+
+    pointHistory {
+        bigint id PK "포인트 히스토리 ID"
+        bigint ref_point_id FK "포인트 ID"
+        bigint amount "포인트 변동 금액"
+        string balance "포인트 잔액"
+    }
+
+    order {
+        bigint id PK "주문 ID"
+        bigint ref_user_id FK "유저 ID"
+        bigint totalPrice "총 주문 금액"
+    }
+
+    user ||--o{ order: "referenced"
+    order ||--o{ orderLine: "referenced"
+
+    orderLine {
+        bigint id PK "주문 라인 ID"
+        bigint ref_order_id FK "주문 ID"
+        bigint ref_product_id FK "상품 ID"
+        bigint quantity "상품 수량"
+        bigint price "상품 개별 가격"
+    }
+
+    product ||--o{ orderLine: "referenced"
+
 ```


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

### 상품 목록 조회 설계에서의 고민

상품 목록 조회 시, 필터링을 위한 brandId가 존재하지 않는 브랜드인 경우 에러 응답을 할지에 대해 고민하였습니다.
국내 최고의 감성 이커머스(29CM)에서는 에러 응답 대신 200 SUCCESS와 함께 빈 배열로 응답하였습니다.
그 이유에 대해서 고민해 본 결과

없는 brand id를 입력하기 위해서는 쿼리 파라미터를 직접 수정해야 하는데, 일반적인 경우가 아니기 때문에 모두 존재하는 brand id로 가정하고 처리한다.
여러 brand id를 사용하여 조회하는 경우, 없는 브랜드에 대한 validation으로 404 응답을 주는 대신, 존재하는 브랜드의 상품 목록이라도 응답해 주기 위함이다.
이렇게 두 가지 이유로 생각했습니다.
특히 두 번째 이유는 이커머스의 매출에도 도움이 되는 방식이라 생각됩니다.
따라서 상품 목록 조회에서는 요청이 잘못되어도 최대한 응답을 해줄 수 있도록 페이지 네이션의 조건들(page, size, sort)도 잘못된 값이 들어와도 기본값을 사용할 수 있도록 했습니다.

### 상품 상세 조회 설계에서의 고민

상품은 존재하지만 상품의 브랜드가 존재하지 않는 경우에 대한 처리를 고민했습니다.
일단 상품의 브랜드가 존재하지 않는 상품은 판매할 수 없다고 생각합니다.
브랜드가 없다면, 판매된 상품의 품질 보장, 검수 등에 어려움이 있을 것입니다.
따라서 에러 응답을 줘야 합니다.

어떤 에러 응답을 줄지 결정하기 위해 고민해 본 "상품의 브랜드가 존재하지 않는 이유"는

product.ref_brand_id 가 null이다 -> ref_brand_id는 nullable = false로 설정할 예정이라 불가능
product.ref_brand_id와 일치하는 brand가 존재하지 않는다. -> 상품 생성 시에 ref_brand_id가 잘못된 값으로 설정되었거나, 브랜드가 삭제, 변경될 때 상품에 대한 처리 누락이 발생했다.
이렇게 두 가지로 생각됩니다.
두 번째 케이스에서는 유저가 요청을 수정해서 해결할 수 있는 것이 아니기 때문에 400번대 에러는 적절하지 않습니다.
원인이 서버의 로직이 잘못된 것이고, 이를 인지하고 버그를 수정해야 하기 때문에 500 Internal Server Error를 응답하도록 하였습니다.

### 상품 좋아요 목록 조회 설계에서의 고민

상품 좋아요 목록 조회시에, 상품 좋아요의 상품이 존재하지 않는 경우에 대해서 에러 응답 없이 해당 상품을 제외하고 응답하도록 했습니다.
상품이 삭제된 경우, 나머지 상품에 대해서 조회 가능해야하기 때문입니다.

### 주문 생성 설계에서의 고민

ER 다이어그램을 작성할 때, point를 user에 포함시킬지, stock을 product에 포함시킬지에 대해 고민했습니다.

멘토링 중에 말씀해주신 point가 없다고 유저가 생성 안되는 것은 말이 안되고, 둘은 독립성이 보장되어야 한다 는 말씀에 공감했습니다.
하지만 포인트가 유일한 결제 수단인 이커머스에서는, 유저가 생성될 때 포인트도 0으로 함께 생성되어야 한다고 생각하여 분리하지 않는 것을 고민했습니다.
현재는 포인트가 유일한 결제 수단이지만, 이후에 포인트는 마일리지 정도의 역할을 하게 된다는 것을 고려해서 포인트를 유저 테이블과 분리하는 것으로 결정했습니다.

상품 재고는 아래와 같은 이유로 상품 테이블에 포함시키지 않았습니다.

상품 재고는 write가 다양한 경로로 많이 발생하고, 상품은 read가 다양한 경로로 많이 발생하기 때문에 이 둘을 분리시켜 한 테이블에 read와 write가 몰리는 것을 분리하고자 했습니다.
상품 재고에 문제가 발생해서 조회가 안될 때, 상품까지 조회가 안되는 것을 방지하기 위한 목적으로 분리했습니다. 이커머스에서 상품이 조회가 안되는 것은 매우 치명적이라고 생각했기 때문입니다.

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
- [x] 상품 목록 조회 설계
- [x] 상품 상세 조회 설계
- [x] 브랜드 조회 설계
- [x] 상품 좋아요 설계
- [x] 주문 생성 및 결제 흐름 설계

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->
[29CM 없는 brand id로 상품 목록 조회](https://shop.29cm.co.kr/category/list?categoryLargeCode=272100100&categoryMediumCode=&sort=RECOMMEND&defaultSort=RECOMMEND&sortOrder=DESC&page=1&brands=12310576&categorySmallCode=&minPrice=0&maxPrice=&isFreeShipping=&excludeSoldOut=&isDiscount=&colors=&tag=&extraFacets=&attributes=%5B%5D&ticketStartDate=&ticketEndDate=)