### PR TITLE
[round-4] 재고/포인트/쿠폰 정합성 보장 및 동시성 이슈 제어

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
@@ -12,6 +12,7 @@ public final class OrderCriteria {
 
     public record Order(
             Long userId,
+            Long couponIssuanceId,
             List<OrderProduct> products
     ) {
         public OrderCommand.Create toOrderCommand() {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,33 +1,62 @@
 package com.loopers.application.order;
 
-import com.loopers.application.user.UserFacade;
+import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.order.OrderInfo;
 import com.loopers.domain.order.OrderService;
+import com.loopers.domain.point.PointService;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.ProductStockCommand;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderFacade {
     private final OrderService orderService;
     private final ProductService productService;
-    private final UserFacade userFacade;
+    private final PointService pointService;
+    private final CouponService couponService;
 
+    @Transactional
     public OrderResult.Order order(OrderCriteria.Order criteria) {
+        OrderInfo.Create orderInfo = createOrder(criteria);
+        Long discountingAmount = useCoupon(criteria, orderInfo);
+        Long discountedPrice = applyDiscount(orderInfo, discountingAmount);
+        usePoint(criteria, discountedPrice);
+        deductProductStock(criteria);
+        return OrderResult.Order.from(orderInfo, discountedPrice);
+    }
+
+    private OrderInfo.Create createOrder(OrderCriteria.Order criteria) {
         OrderCommand.Create orderCommand = criteria.toOrderCommand();
-        OrderInfo.Create orderInfo = orderService.create(orderCommand);
+        return orderService.create(orderCommand);
+    }
 
+    private Long useCoupon(OrderCriteria.Order criteria, OrderInfo.Create orderInfo) {
+        if (criteria.couponIssuanceId() == null) {
+            return 0L;
+        }
+        Long couponIssuanceId = criteria.couponIssuanceId();
+        Long orderId = orderInfo.getId();
+        Long orderPrice = orderInfo.getTotalPrice();
+        return couponService.useCoupon(couponIssuanceId, orderId, orderPrice);
+    }
+
+    private Long applyDiscount(OrderInfo.Create orderInfo, Long discountingAmount) {
+        Long orderId = orderInfo.getId();
+        return orderService.applyDiscount(orderId, discountingAmount);
+    }
+
+    private void usePoint(OrderCriteria.Order criteria, Long discountedPrice) {
         Long userId = criteria.userId();
-        Long totalPrice = orderInfo.getTotalPrice();
-        userFacade.usePoint(userId, totalPrice);
+        pointService.usePoint(userId, discountedPrice);
+    }
 
+    private void deductProductStock(OrderCriteria.Order criteria) {
         ProductStockCommand.Deduct productStockCommand = criteria.toProductStockCommand();
         productService.deductStock(productStockCommand);
-
-        return OrderResult.Order.from(orderInfo);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -10,13 +10,18 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class OrderResult {
 
-    public record Order(Long id, Long totalPrice, List<OrderProduct> products) {
-        public static Order from(OrderInfo.Create orderInfo) {
+    public record Order(
+            Long id,
+            Long totalPrice,
+            Long discountedPrice,
+            List<OrderProduct> products
+    ) {
+        public static Order from(OrderInfo.Create orderInfo, Long discountedPrice) {
             List<OrderProduct> products = orderInfo.getItems()
                     .stream()
                     .map(OrderProduct::from)
                     .toList();
-            return new Order(orderInfo.getId(), orderInfo.getTotalPrice(), products);
+            return new Order(orderInfo.getId(), orderInfo.getTotalPrice(), discountedPrice, products);
         }
 
         public record OrderProduct(Long productId, Long quantity, Long price) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -1,0 +1,21 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointFacade {
+
+    private final PointService pointService;
+
+    public Long getPoint(Long userId) {
+        return pointService.getPoint(userId);
+    }
+
+    public Long chargePoint(Long userId, Long amount) {
+        return pointService.chargePoint(userId, amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserReader.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserReader.java
@@ -2,7 +2,6 @@ package com.loopers.application.user;
 
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.vo.LoginId;
-import com.loopers.domain.user.vo.Point;
 
 import java.util.Optional;
 
@@ -10,6 +9,4 @@ public interface UserReader {
     boolean exists(LoginId loginId);
 
     Optional<User> find(long userId);
-
-    Optional<Point> findPoint(long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/AmountDiscountCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/AmountDiscountCoupon.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.vo.DiscountAmount;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("AMOUNT_DISCOUNT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AmountDiscountCoupon extends Coupon {
+
+    @Embedded
+    private DiscountAmount discountAmount;
+
+    private AmountDiscountCoupon(DiscountAmount discountAmount, String name) {
+        super(name);
+        this.discountAmount = discountAmount;
+    }
+
+    public static AmountDiscountCoupon create(Long discountAmount, String name) {
+        return new AmountDiscountCoupon(DiscountAmount.of(discountAmount), name);
+    }
+
+    @Override
+    public Long calculateDiscountAmount(Long orderPrice) {
+        if (orderPrice == null || orderPrice <= 0) {
+            throw new IllegalArgumentException("null이거나 0 이하의 주문 금액은 할인할 수 없습니다.");
+        }
+        return Math.min(orderPrice, discountAmount.toLong());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.coupon.vo.CouponName;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "coupon")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(
+        name = "coupon_type",
+        discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class Coupon extends BaseEntity {
+    @Embedded
+    private CouponName name;
+
+    protected Coupon(String name) {
+        this.name = CouponName.of(name);
+    }
+
+    public abstract Long calculateDiscountAmount(Long orderPrice);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponIssuance.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponIssuance.java
@@ -1,0 +1,55 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "coupon_issuance")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponIssuance extends BaseEntity {
+    private Long couponId;
+    private Long userId;
+    private Long usedOrderId;
+    private ZonedDateTime usedAt;
+
+    @Version
+    private Long version;
+
+    private CouponIssuance(Long couponId, Long userId) {
+        if (couponId == null) {
+            throw new IllegalArgumentException("couponId는 null일 수 없습니다.");
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 null일 수 없습니다.");
+        }
+        this.couponId = couponId;
+        this.userId = userId;
+    }
+
+    public static CouponIssuance create(Long couponId, Long userId) {
+        return new CouponIssuance(couponId, userId);
+    }
+
+    public void use(Long usedOrderId) {
+        if (isUsed()) {
+            throw new IllegalStateException("사용된 쿠폰은 재사용할 수 없습니다.");
+        }
+        this.usedAt = ZonedDateTime.now();
+        if (usedOrderId == null) {
+            throw new IllegalArgumentException("usedOrderId는 null일 수 없습니다.");
+        }
+        this.usedOrderId = usedOrderId;
+    }
+
+    public boolean isUsed() {
+        return this.usedAt != null;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponIssuanceRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponIssuanceRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponIssuanceRepository {
+    CouponIssuance save(CouponIssuance couponIssuance);
+
+    Optional<CouponIssuance> findById(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<Coupon> findById(Long id);
+
+    Coupon save(Coupon coupon);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponService {
+    private final CouponIssuanceRepository couponIssuanceRepository;
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public Long useCoupon(Long couponIssuanceId, Long orderId, Long orderPrice) {
+        CouponIssuance couponIssuance = getCouponIssuance(couponIssuanceId);
+
+        Long couponId = couponIssuance.getCouponId();
+        Coupon coupon = getCoupon(couponId);
+        Long discountAmount = coupon.calculateDiscountAmount(orderPrice);
+
+        couponIssuance.use(orderId);
+        return discountAmount;
+    }
+
+    private CouponIssuance getCouponIssuance(Long couponIssuanceId) {
+        return couponIssuanceRepository.findById(couponIssuanceId)
+                .orElseThrow(() -> new EntityNotFoundException("쿠폰 발급 정보를 찾을 수 없습니다. 쿠폰 발급 ID: " + couponIssuanceId));
+    }
+
+    private Coupon getCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new EntityNotFoundException("쿠폰 정보를 찾을 수 없습니다. 쿠폰 ID: " + couponId));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RateDiscountCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RateDiscountCoupon.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.vo.DiscountRate;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@DiscriminatorValue("RATE_DISCOUNT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RateDiscountCoupon extends Coupon {
+
+    @Embedded
+    private DiscountRate discountRate;
+
+    private RateDiscountCoupon(DiscountRate discountRate, String name) {
+        super(name);
+        this.discountRate = discountRate;
+    }
+
+    public static RateDiscountCoupon create(BigDecimal discountRate, String name) {
+        return new RateDiscountCoupon(DiscountRate.of(discountRate), name);
+    }
+
+    @Override
+    public Long calculateDiscountAmount(Long orderPrice) {
+        if (orderPrice == null || orderPrice <= 0) {
+            throw new IllegalArgumentException("null이거나 0 이하의 주문 금액은 할인할 수 없습니다.");
+        }
+        Long discountAmount = discountRate.calculateDiscountAmount(orderPrice);
+        return Math.min(orderPrice, discountAmount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/CouponName.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/CouponName.java
@@ -1,0 +1,38 @@
+package com.loopers.domain.coupon.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class CouponName {
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 20;
+    private static final String PATTERN = "^[a-zA-Z0-9가-힣\\s]+$";
+
+    @Column(name = "name")
+    private final String value;
+
+    private CouponName(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름은 null이거나 빈 문자열일 수 없습니다.");
+        }
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("쿠폰 이름은 " + MIN_LENGTH + "~" + MAX_LENGTH + "자 이내여야 합니다.");
+        }
+        if (!value.matches(PATTERN)) {
+            throw new IllegalArgumentException("쿠폰 이름은 영어, 숫자, 한글(공백 포함 가능)으로만 구성되어야 합니다.");
+        }
+        this.value = value;
+    }
+
+    public static CouponName of(String value) {
+        return new CouponName(value);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/DiscountAmount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/DiscountAmount.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.coupon.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class DiscountAmount {
+    private static final int MIN_VALUE = 1;
+
+    @Column(name = "discount_value")
+    private final BigDecimal value;
+
+    private DiscountAmount(Long value) {
+        if (value == null) {
+            throw new IllegalArgumentException("할인 금액은 null일 수 없습니다.");
+        }
+        if (value < MIN_VALUE) {
+            throw new IllegalArgumentException("할인 금액은 " + MIN_VALUE + " 이상이어야 합니다.");
+        }
+        this.value = BigDecimal.valueOf(value);
+    }
+
+    public static DiscountAmount of(Long value) {
+        return new DiscountAmount(value);
+    }
+
+    public Long toLong() {
+        return value.longValue();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/DiscountRate.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/vo/DiscountRate.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.coupon.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Getter
+public class DiscountRate {
+    private static final BigDecimal MIN_VALUE = BigDecimal.valueOf(0.01); // 1%
+    private static final BigDecimal MAX_VALUE = BigDecimal.valueOf(1.00); // 100%
+    private static final MathContext MATH_CONTEXT = new MathContext(0, RoundingMode.UP); // 소수점 이하 0자리에서 올림
+
+    private final BigDecimal value;
+
+    private DiscountRate(BigDecimal value) {
+        if (value == null) {
+            throw new IllegalArgumentException("할인율은 null일 수 없습니다.");
+        }
+        if (value.compareTo(MIN_VALUE) < 0 || value.compareTo(MAX_VALUE) > 0) {
+            throw new IllegalArgumentException("할인율은 " + MIN_VALUE + " 이상 " + MAX_VALUE + " 이하이어야 합니다.");
+        }
+        this.value = value;
+    }
+
+    public static DiscountRate of(BigDecimal value) {
+        return new DiscountRate(value);
+    }
+
+    public Long calculateDiscountAmount(Long orderPrice) {
+        BigDecimal decimalOrderPrice = BigDecimal.valueOf(orderPrice);
+        BigDecimal discountAmount = decimalOrderPrice.multiply(value, MATH_CONTEXT);
+        return discountAmount.longValue();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeProductCountRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeProductCountRepository.java
@@ -6,4 +6,8 @@ public interface LikeProductCountRepository {
     LikeProductCount save(LikeProductCount likeProductCount);
 
     Optional<LikeProductCount> find(Long productId);
+
+    Integer increaseLikeCount(Long productId);
+
+    Integer decreaseLikeCount(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -40,30 +40,12 @@ public class LikeService {
 
     @Transactional
     public void increaseLikeProductCount(Long productId) {
-        Optional<LikeProductCount> optional = findLikeProductCount(productId);
-        if (optional.isEmpty()) {
-            return;
-        }
-        LikeProductCount likeProductCount = optional.get();
-        likeProductCount.increase();
+        likeProductCountRepository.increaseLikeCount(productId);
     }
 
     @Transactional
     public void decreaseLikeProductCount(Long productId) {
-        Optional<LikeProductCount> optional = findLikeProductCount(productId);
-        if (optional.isEmpty()) {
-            return;
-        }
-        LikeProductCount likeProductCount = optional.get();
-        likeProductCount.decrease();
-    }
-
-    private Optional<LikeProductCount> findLikeProductCount(Long productId) {
-        Optional<LikeProductCount> optional = likeProductCountRepository.find(productId);
-        if (optional.isEmpty()) {
-            log.error("Like product count not found for productId: {}", productId);
-        }
-        return optional;
+        likeProductCountRepository.decreaseLikeCount(productId);
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.order.vo.DiscountedPrice;
 import com.loopers.domain.order.vo.TotalPrice;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -18,6 +19,8 @@ public class Order extends BaseEntity {
     private Long userId;
     @Embedded
     private TotalPrice totalPrice;
+    @Embedded
+    private DiscountedPrice discountedPrice;
 
     private Order(Long userId, TotalPrice totalPrice) {
         if (userId == null) {
@@ -29,5 +32,16 @@ public class Order extends BaseEntity {
 
     public static Order create(Long userId, Long totalPrice) {
         return new Order(userId, TotalPrice.of(totalPrice));
+    }
+
+    public void applyDiscount(Long discountingAmount) {
+        if (discountingAmount == null) {
+            throw new IllegalArgumentException("할인 금액은 null일 수 없습니다.");
+        }
+        if (discountingAmount < 0) {
+            throw new IllegalArgumentException("할인 금액은 0 이상이어야 합니다.");
+        }
+        Long discountedPriceValue = totalPrice.getValue() - discountingAmount;
+        this.discountedPrice = DiscountedPrice.of(discountedPriceValue);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,5 +1,9 @@
 package com.loopers.domain.order;
 
+import java.util.Optional;
+
 public interface OrderRepository {
     Order save(Order order);
+
+    Optional<Order> findById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/vo/DiscountedPrice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/vo/DiscountedPrice.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.order.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Getter
+public class DiscountedPrice {
+    private static final Long MIN_VALUE = 0L;
+
+    private final Long value;
+
+    private DiscountedPrice(Long value) {
+        if (value == null) {
+            throw new IllegalArgumentException("할인된 가격은 null일 수 없습니다.");
+        }
+        if (value < MIN_VALUE) {
+            throw new IllegalArgumentException("할인된 가격은 " + MIN_VALUE + " 이상이어야 합니다.");
+        }
+        this.value = value;
+    }
+
+    public static DiscountedPrice of(Long value) {
+        return new DiscountedPrice(value);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "point")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Point extends BaseEntity {
+    private Long userId;
+
+    @Embedded
+    private PointBalance balance;
+
+    private Point(Long userId, PointBalance balance) {
+        this.userId = userId;
+        this.balance = balance;
+    }
+
+    public static Point create(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 null일 수 없습니다.");
+        }
+        return new Point(userId, PointBalance.ZERO);
+    }
+
+    public void use(Long amount) {
+        this.balance = this.balance.use(amount);
+    }
+
+    public void charge(Long amount) {
+        this.balance = this.balance.charge(amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointBalance.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointBalance.java
@@ -1,0 +1,59 @@
+package com.loopers.domain.point;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class PointBalance {
+    public static final PointBalance ZERO = new PointBalance(0L);
+    private static final long MIN_BALANCE = 0L;
+    private static final long MIN_CHARGE_AMOUNT = 1L;
+    private static final long MIN_USE_AMOUNT = 1L;
+
+    @Column(name = "balance")
+    private final Long value;
+
+    private PointBalance(Long value) {
+        if (value == null) {
+            throw new IllegalArgumentException("포인트 잔액은 null일 수 없습니다.");
+        }
+        if (value < MIN_BALANCE) {
+            throw new IllegalArgumentException("포인트 잔액은 " + MIN_BALANCE + "보다 작을 수 없습니다.");
+        }
+        this.value = value;
+    }
+
+    public static PointBalance of(Long balance) {
+        return new PointBalance(balance);
+    }
+
+    public PointBalance charge(Long amount) {
+        if (amount == null) {
+            throw new IllegalArgumentException("충전 금액은 null일 수 없습니다.");
+        }
+        if (amount < MIN_CHARGE_AMOUNT) {
+            throw new IllegalArgumentException("충전 금액은 " + MIN_CHARGE_AMOUNT + "보다 커야 합니다.");
+        }
+        return new PointBalance(this.value + amount);
+    }
+
+    public PointBalance use(Long amount) {
+        if (amount == null) {
+            throw new IllegalArgumentException("사용 금액은 null일 수 없습니다.");
+        }
+        if (amount < MIN_USE_AMOUNT) {
+            throw new IllegalArgumentException("사용 금액은 " + MIN_USE_AMOUNT + "보다 커야 합니다.");
+        }
+        if (this.value < amount) {
+            throw new IllegalArgumentException("포인트 잔액이 부족합니다.");
+        }
+        return new PointBalance(this.value - amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.point;
+
+import java.util.Optional;
+
+public interface PointRepository {
+    Optional<Point> findByUserId(Long userId);
+
+    Optional<Point> findByUserIdWithLock(Long userId);
+
+    Point save(Point point);
+
+    boolean existsByUserId(Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.point;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    @Transactional
+    public Long usePoint(Long userId, Long amount) {
+        Point point = getPointWithLock(userId);
+        point.use(amount);
+        return point.getBalance().getValue();
+    }
+
+    @Transactional
+    public Long chargePoint(Long userId, Long amount) {
+        Point point = getPointWithLock(userId);
+        point.charge(amount);
+        return point.getBalance().getValue();
+    }
+
+    @Transactional
+    public void createPoint(Long userId) {
+        if (pointRepository.existsByUserId(userId)) {
+            return;
+        }
+        Point point = Point.create(userId);
+        pointRepository.save(point);
+    }
+
+    public Long getPoint(Long userId) {
+        Point point = getPointByUserId(userId);
+        return point.getBalance().getValue();
+    }
+
+    private Point getPointWithLock(Long userId) {
+        return pointRepository.findByUserIdWithLock(userId)
+                .orElseThrow(() -> new EntityNotFoundException("유저의 포인트 정보를 찾을 수 없습니다. userId: " + userId));
+    }
+
+    private Point getPointByUserId(Long userId) {
+        return pointRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("유저의 포인트 정보를 찾을 수 없습니다. userId: " + userId));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -19,17 +19,17 @@ public class ProductService {
     public void deductStock(ProductStockCommand.Deduct command) {
         command.products()
                 .stream()
-                .forEach(product -> deductStock(product));
+                .forEach(this::deductStock);
     }
 
     private ProductStock deductStock(ProductStockCommand.Deduct.Product product) {
-        ProductStock productStock = getProductStock(product.productId());
+        ProductStock productStock = getProductStockWithLock(product.productId());
         productStock.deduct(product.quantityToDeduct());
         return productStock;
     }
 
-    private ProductStock getProductStock(Long productId) {
-        return productStockRepository.findByProductId(productId)
+    private ProductStock getProductStockWithLock(Long productId) {
+        return productStockRepository.findByProductIdWithLock(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 재고 데이터가 존재하지 않습니다. productId: " + productId));
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockRepository.java
@@ -6,4 +6,6 @@ public interface ProductStockRepository {
     ProductStock save(ProductStock productStock);
 
     Optional<ProductStock> findByProductId(Long productId);
+
+    Optional<ProductStock> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/ProductStockQuantity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/ProductStockQuantity.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.product.vo;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -22,10 +20,10 @@ public class ProductStockQuantity {
 
     private ProductStockQuantity(Long value) {
         if (value == null) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "재고 수량은 null일 수 없습니다.");
+            throw new IllegalArgumentException("재고 수량은 null일 수 없습니다.");
         }
         if (value < MIN_VALUE) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "재고 수량은 " + MIN_VALUE + "보다 작을 수 없습니다.");
+            throw new IllegalArgumentException("재고 수량은 " + MIN_VALUE + "보다 작을 수 없습니다.");
         }
         this.value = value;
     }
@@ -36,13 +34,13 @@ public class ProductStockQuantity {
 
     public ProductStockQuantity deduct(Long quantityToDeduct) {
         if (quantityToDeduct == null) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "차감할 수량은 null일 수 없습니다.");
+            throw new IllegalArgumentException("차감할 수량은 null일 수 없습니다.");
         }
         if (quantityToDeduct < MIN_VALUE_FOR_DEDUCT) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "차감할 수량은 " + MIN_VALUE_FOR_DEDUCT + "보다 작을 수 없습니다.");
+            throw new IllegalArgumentException("차감할 수량은 " + MIN_VALUE_FOR_DEDUCT + "보다 작을 수 없습니다.");
         }
         if (this.value < quantityToDeduct) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
+            throw new IllegalStateException("재고가 부족합니다.");
         }
         return new ProductStockQuantity(this.value - quantityToDeduct);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -4,7 +4,6 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.vo.BirthDate;
 import com.loopers.domain.user.vo.Email;
 import com.loopers.domain.user.vo.LoginId;
-import com.loopers.domain.user.vo.Point;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,15 +22,12 @@ public class User extends BaseEntity {
     private Email email;
     @Embedded
     private BirthDate birthDate;
-    @Embedded
-    private Point point;
 
-    private User(LoginId loginId, Gender gender, Email email, BirthDate birthDate, Point point) {
+    private User(LoginId loginId, Gender gender, Email email, BirthDate birthDate) {
         this.loginId = loginId;
         this.gender = gender;
         this.email = email;
         this.birthDate = birthDate;
-        this.point = point;
     }
 
     public static User register(String loginId, String gender, String email, String birthDate) {
@@ -39,16 +35,7 @@ public class User extends BaseEntity {
                 LoginId.of(loginId),
                 Gender.from(gender),
                 Email.of(email),
-                BirthDate.of(birthDate),
-                Point.ZERO
+                BirthDate.of(birthDate)
         );
-    }
-
-    public void chargePoint(long point) {
-        this.point = this.point.charge(point);
-    }
-
-    public void usePoint(Long point) {
-        this.point = this.point.use(point);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -2,15 +2,16 @@ package com.loopers.domain.user;
 
 import com.loopers.application.user.UserReader;
 import com.loopers.domain.user.vo.LoginId;
-import com.loopers.domain.user.vo.Point;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-@RequiredArgsConstructor
+
 @Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserService implements UserReader {
     private final UserRepository userRepository;
 
@@ -24,12 +25,5 @@ public class UserService implements UserReader {
     @Transactional(readOnly = true)
     public Optional<User> find(long id) {
         return userRepository.find(id);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<Point> findPoint(long id) {
-        Optional<User> optionalUser = userRepository.find(id);
-        return optionalUser.map(User::getPoint);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponIssuanceJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponIssuanceJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponIssuance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponIssuanceJpaRepository extends JpaRepository<CouponIssuance, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponIssuanceRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponIssuanceRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponIssuance;
+import com.loopers.domain.coupon.CouponIssuanceRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssuanceRepositoryImpl implements CouponIssuanceRepository {
+    private final CouponIssuanceJpaRepository couponIssuanceJpaRepository;
+
+    @Override
+    public CouponIssuance save(CouponIssuance couponIssuance) {
+        return couponIssuanceJpaRepository.save(couponIssuance);
+    }
+
+    @Override
+    public Optional<CouponIssuance> findById(Long id) {
+        return couponIssuanceJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<Coupon> findById(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeProductCountJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeProductCountJpaRepository.java
@@ -2,9 +2,19 @@ package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.LikeProductCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface LikeProductCountJpaRepository extends JpaRepository<LikeProductCount, Long> {
     Optional<LikeProductCount> findByProductId(Long productId);
+
+    @Modifying
+    @Query("UPDATE LikeProductCount l SET l.countValue.value = l.countValue.value + 1 WHERE l.productId = :productId")
+    Integer increaseLikeCount(Long productId);
+
+    @Modifying
+    @Query("UPDATE LikeProductCount l SET l.countValue.value = l.countValue.value - 1 WHERE l.productId = :productId")
+    Integer decreaseLikeCount(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeProductCountRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeProductCountRepositoryImpl.java
@@ -22,4 +22,14 @@ public class LikeProductCountRepositoryImpl implements LikeProductCountRepositor
     public Optional<LikeProductCount> find(Long productId) {
         return likeProductCountJpaRepository.findByProductId(productId);
     }
+
+    @Override
+    public Integer increaseLikeCount(Long productId) {
+        return likeProductCountJpaRepository.increaseLikeCount(productId);
+    }
+
+    @Override
+    public Integer decreaseLikeCount(Long productId) {
+        return likeProductCountJpaRepository.decreaseLikeCount(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderRepositoryImpl implements OrderRepository {
@@ -13,5 +15,9 @@ public class OrderRepositoryImpl implements OrderRepository {
 
     public Order save(Order order) {
         return orderJpaRepository.save(order);
+    }
+
+    public Optional<Order> findById(Long id) {
+        return orderJpaRepository.findById(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.Point;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+
+public interface PointJpaRepository extends JpaRepository<Point, Long> {
+    Optional<Point> findByUserId(Long userId);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.userId = :userId")
+    Optional<Point> findByUserIdWithLock(Long userId);
+
+    boolean existsByUserId(Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -2,9 +2,11 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import java.util.Optional;
 
@@ -13,6 +15,7 @@ public interface PointJpaRepository extends JpaRepository<Point, Long> {
     Optional<Point> findByUserId(Long userId);
 
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "javax.persistence.lock.timeout", value = "5000"))
     @Query("SELECT p FROM Point p WHERE p.userId = :userId")
     Optional<Point> findByUserIdWithLock(Long userId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointRepositoryImpl implements PointRepository {
+    private final PointJpaRepository pointJpaRepository;
+
+    @Override
+    public Optional<Point> findByUserId(Long userId) {
+        return pointJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<Point> findByUserIdWithLock(Long userId) {
+        return pointJpaRepository.findByUserIdWithLock(userId);
+    }
+
+    @Override
+    public Point save(Point point) {
+        return pointJpaRepository.save(point);
+    }
+
+    @Override
+    public boolean existsByUserId(Long userId) {
+        return pointJpaRepository.existsByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockJpaRepository.java
@@ -1,10 +1,17 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductStock;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ProductStockJpaRepository extends JpaRepository<ProductStock, Long> {
     Optional<ProductStock> findByProductId(Long productId);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ps FROM ProductStock ps WHERE ps.productId = :productId")
+    Optional<ProductStock> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockJpaRepository.java
@@ -2,9 +2,11 @@ package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductStock;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import java.util.Optional;
 
@@ -12,6 +14,7 @@ public interface ProductStockJpaRepository extends JpaRepository<ProductStock, L
     Optional<ProductStock> findByProductId(Long productId);
 
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "javax.persistence.lock.timeout", value = "5000"))
     @Query("SELECT ps FROM ProductStock ps WHERE ps.productId = :productId")
     Optional<ProductStock> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductStockRepositoryImpl.java
@@ -22,4 +22,9 @@ public class ProductStockRepositoryImpl implements ProductStockRepository {
     public Optional<ProductStock> findByProductId(Long productId) {
         return productStockJpaRepository.findByProductId(productId);
     }
+
+    @Override
+    public Optional<ProductStock> findByProductIdWithLock(Long productId) {
+        return productStockJpaRepository.findByProductIdWithLock(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -3,13 +3,14 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.domain.user.vo.LoginId;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRepositoryImpl implements UserRepository {
     private final UserJpaRepository userJpaRepository;
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -122,8 +123,26 @@ public class ApiControllerAdvice {
     }
 
     @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(IllegalArgumentException e) {
+        String message = e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다.";
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(IllegalStateException e) {
+        String message = e.getMessage() != null ? e.getMessage() : "잘못된 상태입니다.";
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
     public ResponseEntity<ApiResponse<?>> handleNotFound(NoResourceFoundException e) {
         return failureResponse(ErrorType.NOT_FOUND, null);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleNotFound(EntityNotFoundException e) {
+        String message = e.getMessage() != null ? e.getMessage() : "요청한 리소스를 찾을 수 없습니다.";
+        return failureResponse(ErrorType.NOT_FOUND, message);
     }
 
     @ExceptionHandler

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Order V1 API", description = "주문 관련 API입니다.")
+public interface OrderV1ApiSpec {
+    @Operation(
+            summary = "주문 생성",
+            description = "상품의 재고를 차감하고, 유저의 포인트를 차감하고, 쿠폰을 사용하여 주문을 생성합니다. "
+    )
+    ApiResponse<OrderV1Dto.CreateOrder.Response> createOrder(
+            @Schema(
+                    name = "X-USER-ID",
+                    description = "조회할 사용자의 ID"
+            )
+            Long userId,
+            @Schema(
+                    name = "주문 생성 요청",
+                    description = "주문 생성에 필요한 정보를 담고 있는 요청 객체"
+            )
+            OrderV1Dto.CreateOrder.Request request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.application.order.OrderCriteria;
+import com.loopers.application.order.OrderFacade;
+import com.loopers.application.order.OrderResult;
+import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderV1Controller implements OrderV1ApiSpec {
+
+    private final OrderFacade orderFacade;
+
+    @Override
+    @PostMapping("/orders")
+    public ApiResponse<OrderV1Dto.CreateOrder.Response> createOrder(
+            @RequestHeader(value = "X-USER-ID") Long userId,
+            @RequestBody @Valid OrderV1Dto.CreateOrder.Request request
+    ) {
+        OrderCriteria.Order criteria = request.toOrderCriteria(userId);
+        OrderResult.Order orderResult = orderFacade.order(criteria);
+        OrderV1Dto.CreateOrder.Response response = OrderV1Dto.CreateOrder.Response.from(orderResult);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -1,0 +1,64 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.application.order.OrderCriteria;
+import com.loopers.application.order.OrderResult;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderV1Dto {
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CreateOrder {
+        public record Request(
+                Long couponIssuanceId,
+                @NotNull
+                @NotEmpty
+                List<OrderProduct> orderProducts
+        ) {
+            public OrderCriteria.Order toOrderCriteria(Long userId) {
+                List<OrderCriteria.Order.OrderProduct> products = orderProducts.stream()
+                        .map(product -> new OrderCriteria.Order.OrderProduct(
+                                product.productId,
+                                product.quantity,
+                                product.price
+                        )).toList();
+                return new OrderCriteria.Order(userId, couponIssuanceId, products);
+            }
+
+            public record OrderProduct(
+                    @NotNull
+                    Long productId,
+                    @NotNull
+                    Long quantity,
+                    @NotNull
+                    Long price
+            ) {
+            }
+        }
+
+        public record Response(
+                Long orderId,
+                Long totalPrice,
+                Long discountedPrice,
+                List<OrderItem> items
+        ) {
+            public static Response from(OrderResult.Order order) {
+                List<OrderItem> items = order.products().stream()
+                        .map(item -> new OrderItem(item.productId(), item.quantity(), item.price()))
+                        .toList();
+                return new Response(order.id(), order.totalPrice(), order.discountedPrice(), items);
+            }
+
+            public record OrderItem(
+                    Long productId,
+                    Long quantity,
+                    Long price
+            ) {
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,38 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Point V1 API", description = "유저의 포인트 관련 API입니다.")
+public interface PointV1ApiSpec {
+    @Operation(
+            summary = "포인트 조회",
+            description = "유저의 포인트 정보를 조회합니다."
+    )
+    ApiResponse<PointV1Dto.GetPoint.Response> getPoint(
+            @Schema(
+                    name = "X-USER-ID",
+                    description = "조회할 사용자의 ID"
+            )
+            Long userId
+    );
+
+    @Operation(
+            summary = "포인트 충전",
+            description = "유저의 포인트를 충전합니다."
+    )
+    ApiResponse<PointV1Dto.ChargePoint.Response> chargePoint(
+            @Schema(
+                    name = "X-USER-ID",
+                    description = "조회할 사용자의 ID"
+            )
+            Long userId,
+            @Schema(
+                    name = "포인트 충전 요청",
+                    description = "포인트 충전에 필요한 정보를 담고 있는 요청 객체"
+            )
+            PointV1Dto.ChargePoint.Request request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,36 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointV1Controller implements PointV1ApiSpec {
+
+    private final PointFacade pointFacade;
+
+    @Override
+    @GetMapping("/points")
+    public ApiResponse<PointV1Dto.GetPoint.Response> getPoint(
+            @RequestHeader(value = "X-USER-ID") Long userId
+    ) {
+        Long balance = pointFacade.getPoint(userId);
+        PointV1Dto.GetPoint.Response response = new PointV1Dto.GetPoint.Response(balance);
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @PostMapping("/points/charge")
+    public ApiResponse<PointV1Dto.ChargePoint.Response> chargePoint(
+            @RequestHeader(value = "X-USER-ID") Long userId,
+            @RequestBody PointV1Dto.ChargePoint.Request request
+    ) {
+        Long balance = pointFacade.chargePoint(userId, request.amount());
+        PointV1Dto.ChargePoint.Response response = new PointV1Dto.ChargePoint.Response(balance);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.point;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PointV1Dto {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPoint {
+        public record Response(
+                Long balance
+        ) {
+        }
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ChargePoint {
+        public record Request(
+                Long amount
+        ) {
+        }
+
+        public record Response(
+                Long balance
+        ) {
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -31,33 +31,4 @@ public interface UserV1ApiSpec {
             )
             Long userId
     );
-
-    @Operation(
-            summary = "포인트 조회",
-            description = "유저의 포인트 정보를 조회합니다."
-    )
-    ApiResponse<UserV1Dto.PointResponse> getPoint(
-            @Schema(
-                    name = "X-USER-ID",
-                    description = "조회할 사용자의 ID"
-            )
-            Long userId
-    );
-
-    @Operation(
-            summary = "포인트 충전",
-            description = "유저의 포인트를 충전합니다."
-    )
-    ApiResponse<UserV1Dto.PointChargeResponse> chargePoint(
-            @Schema(
-                    name = "X-USER-ID",
-                    description = "조회할 사용자의 ID"
-            )
-            Long userId,
-            @Schema(
-                    name = "포인트 충전 요청",
-                    description = "포인트 충전에 필요한 정보를 담고 있는 요청 객체"
-            )
-            UserV1Dto.PointChargeRequest request
-    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -4,12 +4,13 @@ import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import jakarta.validation.Valid;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserV1Controller implements UserV1ApiSpec {
     private final UserFacade userFacade;
 
@@ -31,27 +32,6 @@ public class UserV1Controller implements UserV1ApiSpec {
     ) {
         UserInfo userInfo = userFacade.getUser(userId);
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
-        return ApiResponse.success(response);
-    }
-
-    @Override
-    @GetMapping("/points")
-    public ApiResponse<UserV1Dto.PointResponse> getPoint(
-            @RequestHeader(value = "X-USER-ID") Long userId
-    ) {
-        Long point = userFacade.getPoint(userId);
-        UserV1Dto.PointResponse response = new UserV1Dto.PointResponse(point);
-        return ApiResponse.success(response);
-    }
-
-    @Override
-    @PostMapping("/points/charge")
-    public ApiResponse<UserV1Dto.PointChargeResponse> chargePoint(
-            @RequestHeader(value = "X-USER-ID") Long userId,
-            @RequestBody @Valid UserV1Dto.PointChargeRequest request
-    ) {
-        Long point = userFacade.chargePoint(userId, request.point());
-        UserV1Dto.PointChargeResponse response = new UserV1Dto.PointChargeResponse(point);
         return ApiResponse.success(response);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.LikeProduct;
+import com.loopers.domain.like.LikeProductCount;
+import com.loopers.domain.like.LikeProductCountRepository;
+import com.loopers.domain.like.LikeProductRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class LikeFacadeIntegrationTest {
+
+    @Autowired
+    private LikeFacade likeFacade;
+
+    @Autowired
+    private LikeProductRepository likeProductRepository;
+
+    @Autowired
+    private LikeProductCountRepository likeProductCountRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("한 상품에 대해 좋아요와 좋아요 취소를 할때,")
+    class LikeAndCancelLikeProduct {
+
+        @Test
+        @DisplayName("10명의 유저가 하나의 상품에 대해 동시에 좋아요를 누르면, 해당 상품의 좋아요 카운트는 10이 되어야 한다.")
+        void shouldLikeProductCorrectlyWhenMultipleUsersLike() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long productId = 1L;
+            LikeProductCount likeProductCount = LikeProductCount.create(productId);
+            likeProductCountRepository.save(likeProductCount);
+
+            Long expectedLikeCount = likeProductCount.getCountValue().getValue() + threadCount;
+
+            // Act
+            for (long i = 1; i <= threadCount; i++) {
+                final long userId = i;
+                executorService.submit(() -> {
+                    try {
+                        likeFacade.likeProduct(userId, productId);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            LikeProductCount likeProductCountAfterRequest = likeProductCountRepository.find(productId).get();
+            assertThat(likeProductCountAfterRequest.getCountValue().getValue()).isEqualTo(expectedLikeCount);
+        }
+
+        @Test
+        @DisplayName("10명의 유저가 하나의 상품에 대해 동시에 좋아요 취소를 하면, 해당 상품의 좋아요 카운트는 0이 되어야 한다.")
+        void shouldCancelLikeProductCorrectlyWhenMultipleUsersCancelLike() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long productId = 1L;
+            LikeProductCount likeProductCount = LikeProductCount.create(productId);
+            likeProductCountRepository.save(likeProductCount);
+
+            // 먼저 좋아요를 누름
+            for (long i = 1; i <= threadCount; i++) {
+                final long userId = i;
+                likeFacade.likeProduct(userId, productId);
+            }
+
+            LikeProductCount likeProductCountAfterCreateLike = likeProductCountRepository.find(productId).get();
+            Long likeCountAfterCreateLike = likeProductCountAfterCreateLike.getCountValue().getValue();
+            Long expectedLikeCountAfterCancel = likeCountAfterCreateLike - threadCount;
+
+            // Act
+            for (long i = 1; i <= threadCount; i++) {
+                final long userId = i;
+                executorService.submit(() -> {
+                    try {
+                        likeFacade.cancelLikeProduct(userId, productId);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            LikeProductCount likeProductCountAfterRequest = likeProductCountRepository.find(productId).get();
+            assertThat(likeProductCountAfterRequest.getCountValue().getValue()).isEqualTo(expectedLikeCountAfterCancel);
+        }
+
+        @Test
+        @DisplayName("10명의 유저가 하나의 상품에 대해 동시에 좋아요를 누르고 또 다른 10명의 유저가 싫어요를 누르면, 해당 상품의 좋아요 카운트는 이전과 동일해야한다.")
+        void shouldLikeAndCancelLikeProductCorrectlyWhenMultipleUsersLikeAndCancel() {
+            // Arrange
+            int threadCount = 20;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long productId = 1L;
+            LikeProductCount likeProductCount = LikeProductCount.create(productId);
+            likeProductCountRepository.save(likeProductCount);
+
+            for (long i = 1; i <= threadCount / 2; i++) {
+                LikeProduct likeProduct = LikeProduct.create(i, productId);
+                likeProductRepository.save(likeProduct);
+            }
+
+            LikeProductCount likeProductCountAfterCreateLike = likeProductCountRepository.find(productId).get();
+            Long expectedLikeCount = likeProductCountAfterCreateLike.getCountValue().getValue();
+
+            // Act
+            for (long i = 1; i <= threadCount / 2; i++) {
+                final long userId = i;
+                executorService.submit(() -> {
+                    try {
+                        likeFacade.cancelLikeProduct(userId, productId);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            for (long i = threadCount / 2 + 1; i <= threadCount; i++) {
+                final long userId = i;
+                executorService.submit(() -> {
+                    try {
+                        likeFacade.likeProduct(userId, productId);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            LikeProductCount likeProductCountAfterRequest = likeProductCountRepository.find(productId).get();
+            assertThat(likeProductCountAfterRequest.getCountValue().getValue()).isEqualTo(expectedLikeCount);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.coupon.*;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointFixture;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.*;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class OrderFacadeIntegrationTest {
+
+    @Autowired
+    private OrderFacade orderFacade;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductStockRepository productStockRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponIssuanceRepository couponIssuanceRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("주문을 처리할 때,")
+    class CreateOrder {
+
+        @Test
+        @DisplayName("상품의 재고가 부족하면, 주문이 실패하고 포인트와 재고가 차감되지 않고, 쿠폰도 사용되지 않아야 한다.")
+        void shouldNotDeductPointAndStockAndCouponWhenProductStockIsInsufficient() {
+            // Arrange
+            Long initialStock = 1L;
+            Long orderQuantity = 2L;
+            Long productPrice = 10000L;
+            Long pointBalance = productPrice + 1L;
+
+            // 쿠폰과 쿠폰 발급 설정
+            Coupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            Long couponId = savedCoupon.getId();
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId);
+            CouponIssuance savedCouponIssuance = couponIssuanceRepository.save(couponIssuance);
+
+            Long userId = couponIssuance.getUserId();
+
+            // 포인트를 설정
+            Point point = PointFixture.createPointWithUserId(userId);
+            point.charge(pointBalance);
+            pointRepository.save(point);
+
+            // 상품과 재고를 설정
+            Product savedProduct = productRepository.save(ProductFixture.createProductWithPrice(productPrice));
+            productStockRepository.save(ProductStockFixture.createProductStock(savedProduct.getId(), initialStock));
+
+            Long couponIssuanceId = savedCouponIssuance.getId();
+
+            OrderCriteria.Order criteria = new OrderCriteria.Order(
+                    userId,
+                    couponIssuanceId,
+                    List.of(
+                            new OrderCriteria.Order.OrderProduct(savedProduct.getId(), orderQuantity, productPrice)
+                    )
+            );
+
+            // Act && Assert
+            assertThrows(IllegalArgumentException.class, () -> {
+                orderFacade.order(criteria);
+            });
+
+            CouponIssuance couponIssuanceAfterOrderFailed = couponIssuanceRepository.findById(couponIssuanceId).get();
+            assertThat(couponIssuanceAfterOrderFailed.isUsed()).isFalse();
+
+            Point pointAfterOrderFailed = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterOrderFailed.getBalance().getValue()).isEqualTo(pointBalance);
+
+            ProductStock productStockAfterOrderFailed = productStockRepository.findByProductId(savedProduct.getId()).get();
+            assertThat(productStockAfterOrderFailed.getQuantity().getValue()).isEqualTo(initialStock);
+        }
+
+        @Test
+        @DisplayName("포인트가 부족하면, 주문이 실패하고 포인트와 재고가 차감되지 않고, 쿠폰도 사용되지 않아야 한다.")
+        void shouldNotDeductPointAndStockAndCouponWhenPointIsInsufficient() {
+            // Arrange
+            Long initialStock = 10L;
+            Long orderQuantity = 1L;
+            Long productPrice = 10000L;
+            Long pointBalance = 1000L;
+
+            // 쿠폰과 쿠폰 발급 설정
+            Coupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            Long couponId = savedCoupon.getId();
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId);
+            CouponIssuance savedCouponIssuance = couponIssuanceRepository.save(couponIssuance);
+
+            Long userId = couponIssuance.getUserId();
+
+            // 포인트를 설정
+            Point point = PointFixture.createPointWithUserId(userId);
+            point.charge(pointBalance);
+            pointRepository.save(point);
+
+            // 상품과 재고를 설정
+            Product savedProduct = productRepository.save(ProductFixture.createProductWithPrice(productPrice));
+            productStockRepository.save(ProductStockFixture.createProductStock(savedProduct.getId(), initialStock));
+
+            Long couponIssuanceId = savedCouponIssuance.getId();
+
+            OrderCriteria.Order criteria = new OrderCriteria.Order(
+                    userId,
+                    couponIssuanceId,
+                    List.of(
+                            new OrderCriteria.Order.OrderProduct(savedProduct.getId(), orderQuantity, productPrice)
+                    )
+            );
+
+            // Act && Assert
+            assertThrows(IllegalArgumentException.class, () -> {
+                orderFacade.order(criteria);
+            });
+
+            CouponIssuance couponIssuanceAfterOrderFailed = couponIssuanceRepository.findById(couponIssuanceId).get();
+            assertThat(couponIssuanceAfterOrderFailed.isUsed()).isFalse();
+
+            Point pointAfterOrderFailed = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterOrderFailed.getBalance().getValue()).isEqualTo(pointBalance);
+
+            ProductStock productStockAfterOrderFailed = productStockRepository.findByProductId(savedProduct.getId()).get();
+            assertThat(productStockAfterOrderFailed.getQuantity().getValue()).isEqualTo(initialStock);
+        }
+
+        @Test
+        @DisplayName("발급된 쿠폰이 이미 사용되었다면, 주문이 실패하고 포인트와 재고가 차감되지 않아야 한다.")
+        void shouldNotDeductPointAndStockWhenCouponIssuanceIsUsed() {
+            // Arrange
+            Long initialStock = 10L;
+            Long orderQuantity = 1L;
+            Long productPrice = 10000L;
+            Long pointBalance = productPrice + 1L;
+
+            // 쿠폰과 쿠폰 발급 설정
+            Coupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            Long couponId = savedCoupon.getId();
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId);
+            Long usedOrderId = 999L;
+            couponIssuance.use(usedOrderId);
+            CouponIssuance savedCouponIssuance = couponIssuanceRepository.save(couponIssuance);
+
+            Long userId = couponIssuance.getUserId();
+
+            // 포인트를 설정
+            Point point = PointFixture.createPointWithUserId(userId);
+            point.charge(pointBalance);
+            pointRepository.save(point);
+
+            // 상품과 재고를 설정
+            Product savedProduct = productRepository.save(ProductFixture.createProductWithPrice(productPrice));
+            productStockRepository.save(ProductStockFixture.createProductStock(savedProduct.getId(), initialStock));
+
+            Long couponIssuanceId = savedCouponIssuance.getId();
+
+            OrderCriteria.Order criteria = new OrderCriteria.Order(
+                    userId,
+                    couponIssuanceId,
+                    List.of(
+                            new OrderCriteria.Order.OrderProduct(savedProduct.getId(), orderQuantity, productPrice)
+                    )
+            );
+
+            // Act && Assert
+            assertThrows(IllegalStateException.class, () -> {
+                orderFacade.order(criteria);
+            });
+
+            CouponIssuance couponIssuanceAfterOrderFailed = couponIssuanceRepository.findById(couponIssuanceId).get();
+            assertThat(couponIssuanceAfterOrderFailed.isUsed()).isTrue();
+
+            Point pointAfterOrderFailed = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterOrderFailed.getBalance().getValue()).isEqualTo(pointBalance);
+
+            ProductStock productStockAfterOrderFailed = productStockRepository.findByProductId(savedProduct.getId()).get();
+            assertThat(productStockAfterOrderFailed.getQuantity().getValue()).isEqualTo(initialStock);
+        }
+
+        @Test
+        @DisplayName("주문이 성공하면, 포인트와 재고가 차감되고, 쿠폰이 사용되고 주문이 생성된다.")
+        void shouldDeductPointAndStockWhenOrderIsSuccessful() {
+            // Arrange
+            Long initialStock = 10L;
+            Long orderQuantity = 1L;
+            Long productPrice = 10000L;
+            Long pointBalance = productPrice + 1L;
+
+            // 쿠폰과 쿠폰 발급 설정
+            Coupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            Long couponId = savedCoupon.getId();
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId);
+            CouponIssuance savedCouponIssuance = couponIssuanceRepository.save(couponIssuance);
+
+            Long userId = couponIssuance.getUserId();
+
+            // 포인트를 설정
+            Point point = PointFixture.createPointWithUserId(userId);
+            point.charge(pointBalance);
+            pointRepository.save(point);
+
+            // 상품과 재고를 설정
+            Product savedProduct = productRepository.save(ProductFixture.createProductWithPrice(productPrice));
+            productStockRepository.save(ProductStockFixture.createProductStock(savedProduct.getId(), initialStock));
+
+            Long couponIssuanceId = savedCouponIssuance.getId();
+
+            OrderCriteria.Order criteria = new OrderCriteria.Order(
+                    userId,
+                    couponIssuanceId,
+                    List.of(
+                            new OrderCriteria.Order.OrderProduct(savedProduct.getId(), orderQuantity, productPrice)
+                    )
+            );
+
+            // Act
+            orderFacade.order(criteria);
+
+            // Assert
+            CouponIssuance couponIssuanceAfterOrder = couponIssuanceRepository.findById(couponIssuanceId).get();
+            assertThat(couponIssuanceAfterOrder.isUsed()).isTrue();
+
+            Point pointAfterOrder = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterOrder.getBalance().getValue()).isEqualTo(pointBalance - (productPrice - savedCoupon.calculateDiscountAmount(productPrice)));
+
+            ProductStock productStockAfterOrder = productStockRepository.findByProductId(savedProduct.getId()).get();
+            assertThat(productStockAfterOrder.getQuantity().getValue()).isEqualTo(initialStock - orderQuantity);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/user/UserFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/user/UserFacadeIntegrationTest.java
@@ -87,47 +87,4 @@ class UserFacadeIntegrationTest {
             verify(userRepository, times(1)).save(any(User.class));
         }
     }
-
-    @Nested
-    @DisplayName("포인트 충전 시,")
-    class ChargePoint {
-        @Test
-        @DisplayName("존재하지 않는 user.id 충전 시, NotFound 예외가 발생한다.")
-        void throwsNotFoundExceptionWhenUserNotFound() {
-            // arrange
-            long nonExistingUserId = 1L;
-            long chargeAmount = 1000;
-
-            // act
-            CoreException exception = assertThrows(CoreException.class, () -> {
-                userFacade.chargePoint(nonExistingUserId, chargeAmount);
-            });
-
-            // assert
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("존재하는 user.id로 포인트를 충전하면, 충전된 포인트를 반환한다.")
-        void chargesPointSuccessfully() {
-            // arrange
-            String userId = UserFixture.VALID_LOGIN_ID;
-            String gender = UserFixture.VALID_GENDER;
-            String email = UserFixture.VALID_EMAIL;
-            String birthDate = UserFixture.VALID_BIRTH_DATE;
-
-            UserInfo userInfo = userFacade.registerUser(userId, gender, email, birthDate);
-            long id = userInfo.id();
-            long chargeAmount = 1000;
-
-            // act
-            Long chargedPoint = userFacade.chargePoint(id, chargeAmount);
-
-            // assert
-            assertAll(
-                    () -> assertThat(chargedPoint).isNotNull(),
-                    () -> assertThat(chargedPoint).isEqualTo(chargeAmount)
-            );
-        }
-    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/AmountDiscountCouponFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/AmountDiscountCouponFixture.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.coupon;
+
+public class AmountDiscountCouponFixture {
+    private static final String VALID_NAME = "couponName";
+    private static final Long VALID_DISCOUNT_AMOUNT = 1000L;
+
+    public static AmountDiscountCoupon createAmountDiscountCoupon(Long discountAmount, String name) {
+        return AmountDiscountCoupon.create(discountAmount, name);
+    }
+
+    public static AmountDiscountCoupon createAmountDiscountCoupon() {
+        return createAmountDiscountCoupon(VALID_DISCOUNT_AMOUNT, VALID_NAME);
+    }
+
+    public static AmountDiscountCoupon createAmountDiscountCouponWithDiscountAmount(Long discountAmount) {
+        return createAmountDiscountCoupon(discountAmount, VALID_NAME);
+    }
+
+    public static AmountDiscountCoupon createAmountDiscountCouponWithName(String name) {
+        return createAmountDiscountCoupon(VALID_DISCOUNT_AMOUNT, name);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/AmountDiscountCouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/AmountDiscountCouponTest.java
@@ -1,0 +1,116 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AmountDiscountCouponTest {
+
+    @Nested
+    @DisplayName("AmountDiscountCoupon 생성할 때")
+    class CreateAmountDiscountCouponTest {
+
+        @Nested
+        @DisplayName("할인 금액이")
+        class DiscountAmountTest {
+
+            @ParameterizedTest
+            @DisplayName("0 이하의 값이 주어지면, IllegalArgumentException 예외가 발생한다.")
+            @ValueSource(longs = {0, -1, -100})
+            void discountAmountLessThanOrEqualToZeroThrowsException(Long discountAmount) {
+                // arrange
+
+                // act
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                    AmountDiscountCouponFixture.createAmountDiscountCouponWithDiscountAmount(discountAmount);
+                });
+
+                // assert
+                assertThat(exception).isNotNull();
+            }
+
+            @Test
+            @DisplayName("null이 주어지면, IllegalArgumentException 예외가 발생한다.")
+            void discountAmountNullThrowsException() {
+                // arrange
+
+                // act
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                    AmountDiscountCouponFixture.createAmountDiscountCouponWithDiscountAmount(null);
+                });
+
+                // assert
+                assertThat(exception).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("이름이")
+        class NameTest {
+
+            @ParameterizedTest
+            @DisplayName("2~20자 이내의 영어, 숫자, 한글(공백 포함 가능)이 아닌 경우, IllegalArgumentException 예외가 발생한다.")
+            @ValueSource(strings = {
+                    "  ", // 길이 2의 blank 문자열
+                    "a", // 2자 미만
+                    "123456789 123456789 1", // 20자 초과
+                    "abcde!@#$%^&*()" // 특수문자 포함
+            })
+            @NullAndEmptySource
+                // null 또는 빈 문자열도 테스트
+            void nameInvalidThrowsException(String name) {
+                // arrange
+
+                // act
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                    AmountDiscountCouponFixture.createAmountDiscountCouponWithName(name);
+                });
+
+                // assert
+                assertThat(exception).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("할인 금액을 계산할 때")
+    class CalculateDiscountAmountTest {
+
+        @Test
+        @DisplayName("주문 금액이 null이면, IllegalArgumentException 예외가 발생한다.")
+        void orderPriceNullThrowsException() {
+            // arrange
+            AmountDiscountCoupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+
+            // act
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                coupon.calculateDiscountAmount(null);
+            });
+
+            // assert
+            assertThat(exception).isNotNull();
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 금액이 0 이하의 값이면, IllegalArgumentException 예외가 발생한다.")
+        @ValueSource(longs = {0, -1, -100})
+        void orderPriceLessThanOrEqualToZeroThrowsException(Long orderPrice) {
+            // arrange
+            AmountDiscountCoupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+
+            // act
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                coupon.calculateDiscountAmount(orderPrice);
+            });
+
+            // assert
+            assertThat(exception).isNotNull();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponIssuanceFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponIssuanceFixture.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.coupon;
+
+public class CouponIssuanceFixture {
+    private static final Long VALID_COUPON_ID = 1L;
+    private static final Long VALID_USER_ID = 2L;
+
+    public static CouponIssuance createCouponIssuance(Long couponId, Long userId) {
+        return CouponIssuance.create(couponId, userId);
+    }
+
+    public static CouponIssuance createCouponIssuance() {
+        return createCouponIssuance(VALID_COUPON_ID, VALID_USER_ID);
+    }
+
+    public static CouponIssuance createCouponIssuanceWithUserId(Long userId) {
+        return createCouponIssuance(VALID_COUPON_ID, userId);
+    }
+
+    public static CouponIssuance createCouponIssuanceWithCouponId(Long couponId) {
+        return createCouponIssuance(couponId, VALID_USER_ID);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponIssuanceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponIssuanceTest.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CouponIssuanceTest {
+
+    @Nested
+    @DisplayName("쿠폰 발급을 생성할 때")
+    class CreateCouponIssuance {
+
+        @Nested
+        @DisplayName("couponId가")
+        class CouponIdTests {
+
+            @Test
+            @DisplayName("null이면, IllegalArgumentException 예외가 발생한다.")
+            void throwIllegalArgumentExceptionWhenCouponIdIsNull() {
+                // arrange
+                Long couponId = null;
+
+                // act & assert
+                assertThrows(IllegalArgumentException.class,
+                        () -> CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId)
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("userId가")
+        class UserIdTests {
+
+            @Test
+            @DisplayName("null이면, IllegalArgumentException 예외가 발생한다.")
+            void throwIllegalArgumentExceptionWhenUserIdIsNull() {
+                // arrange
+                Long userId = null;
+
+                // act & assert
+                assertThrows(IllegalArgumentException.class,
+                        () -> CouponIssuanceFixture.createCouponIssuanceWithUserId(userId)
+                );
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 발급을 사용하려고 할 때")
+    class UseCouponIssuance {
+
+        @Test
+        @DisplayName("이미 사용된 쿠폰 발급이면, IllegalStateException 예외가 발생한다.")
+        void throwIllegalStateExceptionWhenCouponIssuanceIsUsed() {
+            // arrange
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuance();
+            Long usedOrderId = 1L;
+            couponIssuance.use(usedOrderId);
+
+            // act & assert
+            assertThrows(IllegalStateException.class,
+                    () -> couponIssuance.use(usedOrderId)
+            );
+        }
+
+        @Test
+        @DisplayName("usedOrderId가 null이면, IllegalArgumentException 예외가 발생한다.")
+        void throwExceptionWhenUsedOrderIdIsNull() {
+            // arrange
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuance();
+            Long usedOrderId = null;
+
+            // act & assert
+            assertThrows(IllegalArgumentException.class,
+                    () -> couponIssuance.use(usedOrderId)
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.loopers.domain.coupon;
+
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CouponServiceIntegrationTest {
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponIssuanceRepository couponIssuanceRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("하나의 발급된 쿠폰을 사용할 때")
+    class UseCoupon {
+
+        @Test
+        @DisplayName("한 명의 유저가 동시에 10번 쿠폰을 사용하려고 하면, 1회만 성공하고 나머지는 실패한다.")
+        void shouldUseCouponCorrectlyOneWhenMultipleUsersUse() {
+            // arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long orderId = 10L;
+            Long orderPrice = 10000L;
+
+            // 쿠폰과 쿠폰 발급을 생성
+            Coupon coupon = AmountDiscountCouponFixture.createAmountDiscountCoupon();
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            Long couponId = savedCoupon.getId();
+            CouponIssuance couponIssuance = CouponIssuanceFixture.createCouponIssuanceWithCouponId(couponId);
+            CouponIssuance savedCouponIssuance = couponIssuanceRepository.save(couponIssuance);
+
+            Long couponIssuanceId = savedCouponIssuance.getId();
+            Long expectedVersion = savedCouponIssuance.getVersion() + 1;
+
+            // act
+            for (long i = 1; i <= threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        couponService.useCoupon(couponIssuanceId, orderId, orderPrice);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // assert
+            CouponIssuance updatedCouponIssuance = couponIssuanceRepository.findById(couponIssuanceId).get();
+            assertThat(updatedCouponIssuance.isUsed()).isTrue();
+            assertThat(updatedCouponIssuance.getVersion()).isEqualTo(expectedVersion);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountCouponFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountCouponFixture.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public class RateDiscountCouponFixture {
+    private static final String VALID_NAME = "couponName";
+    private static final BigDecimal VALID_DISCOUNT_RATE = BigDecimal.valueOf(0.1); // 10%
+
+    public static RateDiscountCoupon createRateDiscountCoupon(BigDecimal discountRate, String name) {
+        return RateDiscountCoupon.create(discountRate, name);
+    }
+
+    public static RateDiscountCoupon createRateDiscountCoupon() {
+        return createRateDiscountCoupon(VALID_DISCOUNT_RATE, VALID_NAME);
+    }
+
+    public static RateDiscountCoupon createRateDiscountCouponWithDiscountRate(BigDecimal discountRate) {
+        return createRateDiscountCoupon(discountRate, VALID_NAME);
+    }
+
+    public static RateDiscountCoupon createRateDiscountCouponWithName(String name) {
+        return createRateDiscountCoupon(VALID_DISCOUNT_RATE, name);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountCouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountCouponTest.java
@@ -1,0 +1,131 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RateDiscountCouponTest {
+
+    @Nested
+    @DisplayName("RateDiscountCoupon 생성할 때")
+    class CreateRateDiscountCouponTest {
+
+        @Nested
+        @DisplayName("할인율이")
+        class DiscountRateTest {
+
+            @ParameterizedTest
+            @DisplayName("0 이하의 값이 주어지면, IllegalArgumentException 예외가 발생한다.")
+            @ValueSource(doubles = {0.0, -0.1, -1.0})
+            void throwIllegalArgumentExceptionWhenDiscountRateIsLessThanOrEqualToZero(double rate) {
+                // arrange
+                BigDecimal discountRate = BigDecimal.valueOf(rate);
+
+                // act
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                    RateDiscountCouponFixture.createRateDiscountCouponWithDiscountRate(discountRate);
+                });
+
+                // assert
+                assertThat(exception).isNotNull();
+            }
+
+            @ParameterizedTest
+            @DisplayName("1 초과의 값이 주어지면, IllegalArgumentException 예외가 발생한다.")
+            @ValueSource(doubles = {1.1, 2.0, 100.0})
+            void throwIllegalArgumentExceptionWhenDiscountRateIsGreaterThanOne(double rate) {
+                // arrange
+                BigDecimal discountRate = BigDecimal.valueOf(rate);
+
+                // act && assert
+                assertThrows(IllegalArgumentException.class, () -> {
+                    RateDiscountCouponFixture.createRateDiscountCouponWithDiscountRate(discountRate);
+                });
+            }
+
+            @Test
+            @DisplayName("null이 주어지면, IllegalArgumentException 예외가 발생한다.")
+            void throwIllegalArgumentExceptionWhenDiscountRateIsNull() {
+                // arrange
+                BigDecimal discountRate = null;
+
+                // act && assert
+                assertThrows(IllegalArgumentException.class, () -> {
+                    RateDiscountCouponFixture.createRateDiscountCouponWithDiscountRate(discountRate);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("이름이")
+        class NameTest {
+
+            @ParameterizedTest
+            @DisplayName("2~20자 이내의 영어, 숫자, 한글(공백 포함 가능)이 아닌 경우, IllegalArgumentException 예외가 발생한다.")
+            @ValueSource(strings = {
+                    "  ", // 길이 2의 blank 문자열
+                    "a", // 2자 미만
+                    "123456789 123456789 1", // 20자 초과
+                    "abcde!@#$%^&*()" // 특수문자 포함
+            })
+            @NullAndEmptySource
+                // null 또는 빈 문자열도 테스트
+            void throwIllegalArgumentExceptionWhenNameIsInvalid(String name) {
+                // arrange
+
+                // act
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                    RateDiscountCouponFixture.createRateDiscountCouponWithName(name);
+                });
+
+                // assert
+                assertThat(exception).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("정률 쿠폰 할인 금액을 계산할 때")
+    class CalculateDiscountAmountTest {
+
+        @Test
+        @DisplayName("주문 금액이 null이면, IllegalArgumentException 예외가 발생한다.")
+        void throwIllegalArgumentExceptionWhenOrderPriceIsNull() {
+            // arrange
+            RateDiscountCoupon coupon = RateDiscountCouponFixture.createRateDiscountCoupon();
+            Long orderPrice = null;
+
+            // act
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                coupon.calculateDiscountAmount(orderPrice);
+            });
+
+            // assert
+            assertThat(exception).isNotNull();
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 금액이 0 이하이면, IllegalArgumentException 예외가 발생한다.")
+        @ValueSource(longs = {0, -1, -100})
+        void throwIllegalArgumentExceptionWhenOrderPriceIsZeroOrLess(long orderPrice) {
+            // arrange
+            RateDiscountCoupon coupon = RateDiscountCouponFixture.createRateDiscountCoupon();
+
+            // act
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                coupon.calculateDiscountAmount(orderPrice);
+            });
+
+            // assert
+            assertThat(exception).isNotNull();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -105,31 +105,17 @@ class LikeServiceTest {
     class WhenCallingIncreaseLikeProductCount {
 
         @Test
-        @DisplayName("상품 좋아요 카운트가 존재하면, 상품 좋아요 카운트를 증가시킨다.")
-        void shouldIncreaseLikeProductCountWhenExists() {
+        @DisplayName("상품 좋아요 존재 여부와 상관없이, increaseLikeProductCount 메서드를 호출한다.")
+        void shouldIncreaseLikeProductCountRegardlessOfExistence() {
             // arrange
             Long productId = 1L;
-            LikeProductCount likeProductCount = mock(LikeProductCount.class);
-            when(likeProductCountRepository.find(productId)).thenReturn(Optional.of(likeProductCount));
+            when(likeProductCountRepository.increaseLikeCount(productId)).thenReturn(1);
 
             // act
             likeService.increaseLikeProductCount(productId);
 
             // assert
-            verify(likeProductCount).increase();
-        }
-
-        @Test
-        @DisplayName("상품 좋아요 카운트가 존재하지 않으면, 상품 좋아요 카운트를 증가시키지 않는다.")
-        void shouldNotIncreaseLikeProductCountWhenNotExists() {
-            // arrange
-            Long productId = 1L;
-            when(likeProductCountRepository.find(productId)).thenReturn(Optional.empty());
-
-            // act
-            likeService.increaseLikeProductCount(productId);
-
-            // assert
+            verify(likeProductCountRepository, times(1)).increaseLikeCount(productId);
         }
     }
 
@@ -138,31 +124,17 @@ class LikeServiceTest {
     class WhenCallingDecreaseLikeProductCount {
 
         @Test
-        @DisplayName("상품 좋아요 카운트가 존재하면, 상품 좋아요 카운트를 감소시킨다.")
-        void shouldDecreaseLikeProductCountWhenExists() {
+        @DisplayName("상품 좋아요 존재 여부와 상관없이, decreaseLikeProductCount 메서드를 호출한다.")
+        void shouldDecreaseLikeProductCountRegardlessOfExistence() {
             // arrange
             Long productId = 1L;
-            LikeProductCount likeProductCount = mock(LikeProductCount.class);
-            when(likeProductCountRepository.find(productId)).thenReturn(Optional.of(likeProductCount));
+            when(likeProductCountRepository.decreaseLikeCount(productId)).thenReturn(1);
 
             // act
             likeService.decreaseLikeProductCount(productId);
 
             // assert
-            verify(likeProductCount).decrease();
-        }
-
-        @Test
-        @DisplayName("상품 좋아요 카운트가 존재하지 않으면, 상품 좋아요 카운트를 감소시키지 않는다.")
-        void shouldNotDecreaseLikeProductCountWhenNotExists() {
-            // arrange
-            Long productId = 1L;
-            when(likeProductCountRepository.find(productId)).thenReturn(Optional.empty());
-
-            // act
-            likeService.decreaseLikeProductCount(productId);
-
-            // assert
+            verify(likeProductCountRepository, times(1)).decreaseLikeCount(productId);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointFixture.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.point;
+
+public class PointFixture {
+    private static final Long VALID_USER_ID = 1L;
+
+    public static Point createPoint(Long userId) {
+        return Point.create(userId);
+    }
+
+    public static Point createPoint() {
+        return createPoint(VALID_USER_ID);
+    }
+
+    public static Point createPointWithUserId(Long userId) {
+        return createPoint(userId);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.loopers.domain.point;
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("포인트를 사용하려고 할 때,")
+    class UsePoint {
+
+        @Test
+        @DisplayName("20000 포인트를 가진 한 유저가 동시에 1000 포인트를 10번 사용하면, 최종 포인트는 10000이 되어야 한다.")
+        void shouldUsePointCorrectlyWhenMultipleThreadsAccess() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long userId = 1L;
+            Long initialPoint = 20000L;
+            Point point = Point.create(userId);
+            point.charge(initialPoint);
+            pointRepository.save(point);
+
+            Long amountToUse = 1000L;
+            Long expectedPointAfterUsage = initialPoint - (amountToUse * threadCount);
+
+            // Act
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        // Act
+                        pointService.usePoint(userId, amountToUse);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            Point pointAfterUsage = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterUsage.getBalance().getValue()).isEqualTo(expectedPointAfterUsage);
+        }
+
+        @Test
+        @DisplayName("5000 포인트를 가진 한 유저가 동시에 1000 포인트를 10번 사용하면, 최종 포인트는 0이 되어야 한다.")
+        void shouldUsePointCorrectlyWhenExceedingBalance() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long userId = 1L;
+            Long initialPoint = 5000L;
+            Point point = Point.create(userId);
+            point.charge(initialPoint);
+            pointRepository.save(point);
+
+            Long amountToUse = 1000L;
+            Long expectedPointAfterUsage = 0L;
+
+            // Act
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        // Act
+                        pointService.usePoint(userId, amountToUse);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            Point pointAfterUsage = pointRepository.findByUserId(userId).get();
+            assertThat(pointAfterUsage.getBalance().getValue()).isEqualTo(expectedPointAfterUsage);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
@@ -1,0 +1,174 @@
+package com.loopers.domain.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PointTest {
+
+    @Nested
+    @DisplayName("Point 객체를 생성할 때,")
+    class CreatePoint {
+
+        @Test
+        @DisplayName("userId가 null이면, IllegalArgumentException이 발생한다.")
+        void shouldThrowExceptionWhenUserIdIsNull() {
+            // arrange
+            Long userId = null;
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                Point.create(userId);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("userId가 유효하면, balance가 0인 Point 객체가 생성된다.")
+        void shouldCreatePointWithZeroBalanceWhenUserIdIsValid() {
+            // arrange
+            Long userId = 1L;
+
+            // act
+            Point point = Point.create(userId);
+
+            // assert
+            assertAll(
+                    () -> assertThat(point.getUserId()).isEqualTo(userId),
+                    () -> assertThat(point.getBalance().getValue()).isZero()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Point를 사용할 때,")
+    class UsePoint {
+
+        @Test
+        @DisplayName("사용하려는 금액이 null이면, IllegalArgumentException이 발생한다.")
+        void shouldThrowExceptionWhenUsingNullAmount() {
+            // arrange
+            Point point = Point.create(1L);
+            Long amountToUse = null;
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                point.use(amountToUse);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+
+        @ParameterizedTest
+        @DisplayName("사용하려는 금액이 0이하면, IllegalArgumentException이 발생한다.")
+        @ValueSource(longs = {0L, -1L, -100L})
+        void shouldThrowExceptionWhenUsingZeroOrNegativeAmount(long amountToUse) {
+            // arrange
+            Point point = Point.create(1L);
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                point.use(amountToUse);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("잔액보다 큰 금액을 사용하려고 하면, IllegalArgumentException이 발생한다.")
+        void shouldThrowExceptionWhenUsingMoreThanBalance() {
+            // arrange
+            Point point = Point.create(1L);
+            Long balance = 100L;
+            point.charge(100L);
+            Long amountToUse = balance + 1;
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                point.use(amountToUse);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("잔액보다 적은 금액을 사용하면, 잔액이 감소한다.")
+        void shouldDecreaseBalanceWhenUsingLessThanBalance() {
+            // arrange
+            Point point = Point.create(1L);
+            Long initialBalance = 100L;
+            point.charge(initialBalance);
+            Long amountToUse = 50L;
+            Long expectedBalance = initialBalance - amountToUse;
+
+            // act
+            point.use(amountToUse);
+
+            // assert
+            assertThat(point.getBalance().getValue()).isEqualTo(expectedBalance);
+        }
+    }
+
+    @Nested
+    @DisplayName("Point를 충전할 때,")
+    class ChargePoint {
+
+        @Test
+        @DisplayName("충전하려는 금액이 null이면, IllegalArgumentException이 발생한다.")
+        void shouldThrowExceptionWhenChargingNullAmount() {
+            // arrange
+            Point point = Point.create(1L);
+            Long amountToCharge = null;
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                point.charge(amountToCharge);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+        @ParameterizedTest
+        @DisplayName("충전하려는 금액이 0이하면, IllegalArgumentException이 발생한다.")
+        @ValueSource(longs = {0L, -1L, -100L})
+        void shouldThrowExceptionWhenChargingZeroOrNegativeAmount(long amountToCharge) {
+            // arrange
+            Point point = Point.create(1L);
+
+            // act
+            IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () -> {
+                point.charge(amountToCharge);
+            });
+
+            // assert
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("충전하려는 금액이 0보다 크면, 잔액이 증가한다.")
+        void shouldIncreaseBalanceWhenChargingPositiveAmount() {
+            // arrange
+            Point point = Point.create(1L);
+            Long amountToCharge = 50L;
+
+            // act
+            point.charge(amountToCharge);
+
+            // assert
+            assertThat(point.getBalance().getValue()).isEqualTo(amountToCharge);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductFixture.java
@@ -4,7 +4,7 @@ public class ProductFixture {
     public static final Long VALID_BRAND_ID = 1L;
     public static final String VALID_NAME = "Sample Product";
     public static final long VALID_PRICE = 1000L;
-    public static final String VALID_DESCRIPTION = "This is a sample product description.";
+    public static final String VALID_DESCRIPTION = "This is a sample product description";
 
     public static Product createProduct(Long brandId, Long price, String name, String description) {
         return Product.create(brandId, price, name, description);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.loopers.domain.product;
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProductServiceIntegrationTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductStockRepository productStockRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("상품 재고를 차감할 때,")
+    class DeductStock {
+
+        @Test
+        @DisplayName("재고가 20개인 상품에 동시에 1개 재고 차감 요청이 10개가 들어오면, 재고는 10개가 차감되어야 한다.")
+        void shouldDeductStockCorrectlyWhenMultipleThreadsAccess() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long productId = 1L;
+            Long initialStock = 20L;
+            ProductStock productStock = ProductStock.create(productId, initialStock);
+            productStockRepository.save(productStock);
+
+            Long quantityToDeduct = 1L;
+            ProductStockCommand.Deduct deductCommand = new ProductStockCommand.Deduct(List.of(
+                    new ProductStockCommand.Deduct.Product(productId, quantityToDeduct)
+            ));
+
+            Long expectedStockAfterDeduction = initialStock - (quantityToDeduct * threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        // Act
+                        productService.deductStock(deductCommand);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            ProductStock updatedProductStock = productStockRepository.findByProductId(productId).get();
+            assertThat(updatedProductStock.getQuantity().getValue()).isEqualTo(expectedStockAfterDeduction);
+        }
+
+        @Test
+        @DisplayName("재고가 5개인 상품에 동시에 1개 재고 차감 요청이 10개가 들어오면, 재고는 5개가 차감되어야 한다.")
+        void shouldNotDeductStockBelowZeroWhenMultipleThreadsAccess() {
+            // Arrange
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long productId = 2L;
+            Long initialStock = 5L;
+            ProductStock productStock = ProductStock.create(productId, initialStock);
+            productStockRepository.save(productStock);
+
+            Long quantityToDeduct = 1L;
+            ProductStockCommand.Deduct deductCommand = new ProductStockCommand.Deduct(List.of(
+                    new ProductStockCommand.Deduct.Product(productId, quantityToDeduct)
+            ));
+
+            Long expectedStockAfterDeduction = 0L; // 재고는 0 미만으로 차감되지 않아야 함
+
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        // Act
+                        productService.deductStock(deductCommand);
+                    } catch (Exception e) {
+                        System.out.println("실패: " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                executorService.shutdown();
+            }
+
+            // Assert
+            ProductStock updatedProductStock = productStockRepository.findByProductId(productId).get();
+            assertThat(updatedProductStock.getQuantity().getValue()).isEqualTo(expectedStockAfterDeduction);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductStockTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductStockTest.java
@@ -42,18 +42,15 @@ class ProductStockTest {
         class Stock {
 
             @ParameterizedTest
-            @DisplayName("없거나, 0보다 작으면, BAD_REQUEST 예외가 발생한다")
+            @DisplayName("없거나, 0보다 작으면, IllegalArgumentException 예외가 발생한다")
             @ValueSource(longs = {-1L, -100L})
             @NullSource
                 // null도 테스트
-            void whenStockIsNullOrLessThanZeroThrowsBadRequest(Long stock) {
-                // act
-                CoreException result = assertThrows(CoreException.class, () -> {
+            void whenStockIsNullOrLessThanZeroThrowsIllegalArgumentException(Long stock) {
+                // act && assert
+                assertThrows(IllegalArgumentException.class, () -> {
                     ProductStockFixture.createProductStockWithQuantity(stock);
                 });
-
-                // assert
-                assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
             }
         }
     }
@@ -63,38 +60,32 @@ class ProductStockTest {
     class DeductStock {
 
         @ParameterizedTest
-        @DisplayName("차감하려는 값이 없거나 1 미만인 경우, BAD_REQUEST 예외가 발생한다")
+        @DisplayName("차감하려는 값이 없거나 1 미만인 경우, IllegalArgumentException 예외가 발생한다")
         @ValueSource(longs = {0L, -1L, -100L})
         @NullSource
             // null도 테스트
-        void whenDeductingInvalidStockThrowsBadRequest(Long quantityToDeduct) {
+        void whenDeductingInvalidStockThrowsIllegalArgumentException(Long quantityToDeduct) {
             // arrange
             ProductStock productStock = ProductStockFixture.createProductStockWithQuantity(10L);
 
-            // act
-            CoreException result = assertThrows(CoreException.class, () -> {
+            // act && assert
+            assertThrows(IllegalArgumentException.class, () -> {
                 productStock.deduct(quantityToDeduct);
             });
-
-            // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
         @Test
-        @DisplayName("남은 재고가 차감하려는 수량보다 적은 경우, BAD_REQUEST 예외가 발생한다")
-        void whenDeductingMoreThanAvailableStockThrowsBadRequest() {
+        @DisplayName("남은 재고가 차감하려는 수량보다 적은 경우, IllegalStateException 예외가 발생한다")
+        void whenDeductingMoreThanAvailableStockThrowsIllegalStateException() {
             // arrange
             Long quantity = 10L;
             ProductStock productStock = ProductStockFixture.createProductStockWithQuantity(quantity);
             Long quantityToDeduct = quantity + 1; // 남은 재고보다 1개 더 차감하려고 함
 
-            // act
-            CoreException result = assertThrows(CoreException.class, () -> {
+            // act && assert
+            assertThrows(IllegalStateException.class, () -> {
                 productStock.deduct(quantityToDeduct);
             });
-
-            // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
         @Test

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.user.vo.Point;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -60,40 +59,6 @@ class UserServiceIntegrationTest {
 
             // When
             Optional<User> result = userService.find(nonExistingUserId);
-
-            // Then
-            assertThat(result).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("포인트를 조회할 때")
-    class FindPoint {
-
-        @Test
-        @DisplayName("존재하는 user.id로 조회하면, Optional<Point>를 반환한다.")
-        void findExistingUserPoint() {
-            // Given
-            User existingUser = userRepository.save(UserFixture.createUser());
-            long userId = existingUser.getId();
-
-            // When
-            Optional<Point> foundPoint = userService.findPoint(userId);
-
-            // Then
-            assertAll(
-                    () -> assertThat(foundPoint).hasValue(existingUser.getPoint())
-            );
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 user.id로 조회하면, 빈 Optional을 반환한다.")
-        void findNonExistingUserPoint() {
-            // Given
-            long nonExistingUserId = 1L;
-
-            // When
-            Optional<Point> result = userService.findPoint(nonExistingUserId);
 
             // Then
             assertThat(result).isEmpty();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -44,16 +44,6 @@ class UserTest {
                         () -> assertThat(user.getBirthDate().getBirthDate()).isEqualTo(LocalDate.parse(validBirthDate))
                 );
             }
-
-            @Test
-            @DisplayName("Point가 0으로 초기화된다.")
-            void pointIsInitializedToZero() {
-                // act
-                User user = createUser(validUserId, validGender, validEmail, validBirthDate);
-
-                // assert
-                assertThat(user.getPoint().getBalance()).isZero();
-            }
         }
 
         @Nested
@@ -236,41 +226,6 @@ class UserTest {
                 // assert
                 assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
             }
-        }
-    }
-
-    @Nested
-    @DisplayName("포인트를 충전할 때,")
-    class ChargePoint {
-
-        @ParameterizedTest
-        @DisplayName("0 이하의 값으로 충전하면, BAD_REQUEST 예외가 발생한다.")
-        @ValueSource(longs = {0, -1, -1000})
-        void throwsBadRequestException_whenChargingWithZeroOrNegativeAmount(long amount) {
-            // arrange
-            User user = UserFixture.createUser();
-
-            // act
-            CoreException result = assertThrows(CoreException.class, () -> {
-                user.chargePoint(amount);
-            });
-
-            // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-        }
-
-        @ParameterizedTest
-        @DisplayName("충전 값이 0보다 크면, 포인트가 충전된다.")
-        @ValueSource(longs = {1, 1000})
-        void chargesPointSuccessfully_whenAmountIsPositive(long amount) {
-            // arrange
-            User user = UserFixture.createUser();
-
-            // act
-            user.chargePoint(amount);
-
-            // assert
-            assertThat(user.getPoint().getBalance()).isEqualTo(amount);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ControllerE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ControllerE2ETest.java
@@ -1,0 +1,170 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PointV1ControllerE2ETest {
+    private static final String REGISTER_USER_ENDPOINT = "/api/v1/users";
+    private static final String GET_POINT_ENDPOINT = "/api/v1/points";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public PointV1ControllerE2ETest(
+            TestRestTemplate testRestTemplate,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/points")
+    class GetUserPoint {
+
+        @Test
+        @DisplayName("포인트 조회가 성공할 경우, 사용자의 포인트 정보를 반환한다.")
+        void getUserPointSuccess() {
+            // arrange
+            UserV1Dto.UserRegisterRequest registerRequest = new UserV1Dto.UserRegisterRequest(
+                    "qwer1234",
+                    "M",
+                    "email@gmail.com",
+                    "2000-01-01"
+            );
+
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserRegisterResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var registerResponse = testRestTemplate.exchange(REGISTER_USER_ENDPOINT, HttpMethod.POST, new HttpEntity<>(registerRequest), responseType);
+
+            Long userId = registerResponse.getBody().data().id();
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", userId.toString());
+
+            // act
+            ResponseEntity<ApiResponse<PointV1Dto.GetPoint.Response>> response =
+                    testRestTemplate.exchange(GET_POINT_ENDPOINT, HttpMethod.GET, new HttpEntity<>(headers),
+                            new ParameterizedTypeReference<ApiResponse<PointV1Dto.GetPoint.Response>>() {
+                            });
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data()).isNotNull(),
+                    () -> assertThat(response.getBody().data().balance()).isZero()
+            );
+        }
+
+        @Test
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        void getUserPointWithoutHeader() {
+            // act
+            ResponseEntity<ApiResponse<PointV1Dto.GetPoint.Response>> response =
+                    testRestTemplate.exchange(GET_POINT_ENDPOINT, HttpMethod.GET, null,
+                            new ParameterizedTypeReference<ApiResponse<PointV1Dto.GetPoint.Response>>() {
+                            });
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                    () -> assertThat(response.getBody()).isNotNull()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/points/charge")
+    class ChargeUserPoint {
+
+        private static final String CHARGE_USER_POINT_ENDPOINT = "/api/v1/points/charge";
+
+        @Test
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        void chargeUserPointSuccess() {
+            // arrange
+            UserV1Dto.UserRegisterRequest registerRequest = new UserV1Dto.UserRegisterRequest(
+                    "qwer1234",
+                    "M",
+                    "email@gmail.com",
+                    "2000-01-01"
+            );
+
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserRegisterResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var registerResponse = testRestTemplate.exchange(REGISTER_USER_ENDPOINT, HttpMethod.POST, new HttpEntity<>(registerRequest), responseType);
+
+            Long userId = registerResponse.getBody().data().id();
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", userId.toString());
+
+            ResponseEntity<ApiResponse<PointV1Dto.GetPoint.Response>> getPointResponse =
+                    testRestTemplate.exchange(GET_POINT_ENDPOINT, HttpMethod.GET, new HttpEntity<>(headers),
+                            new ParameterizedTypeReference<ApiResponse<PointV1Dto.GetPoint.Response>>() {
+                            });
+            Long initialPoint = getPointResponse.getBody().data().balance();
+            Long chargingPoint = 1000L;
+
+            PointV1Dto.ChargePoint.Request chargeRequest = new PointV1Dto.ChargePoint.Request(chargingPoint);
+
+            // act
+            ResponseEntity<ApiResponse<PointV1Dto.ChargePoint.Response>> response =
+                    testRestTemplate.exchange(CHARGE_USER_POINT_ENDPOINT, HttpMethod.POST,
+                            new HttpEntity<>(chargeRequest, headers),
+                            new ParameterizedTypeReference<ApiResponse<PointV1Dto.ChargePoint.Response>>() {
+                            });
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data()).isNotNull(),
+                    () -> assertThat(response.getBody().data().balance()).isEqualTo(initialPoint + chargingPoint)
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 UserId로 포인트 충전 시도 시, 404 Not Found 응답을 반환한다.")
+        void chargeUserPointNotFound() {
+            // arrange
+            Long userId = 1L;
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", userId.toString());
+
+            Long chargingPoint = 1000L;
+            PointV1Dto.ChargePoint.Request chargeRequest = new PointV1Dto.ChargePoint.Request(chargingPoint);
+
+            // act
+            ResponseEntity<ApiResponse<PointV1Dto.ChargePoint.Response>> response =
+                    testRestTemplate.exchange(CHARGE_USER_POINT_ENDPOINT, HttpMethod.POST,
+                            new HttpEntity<>(chargeRequest, headers),
+                            new ParameterizedTypeReference<ApiResponse<PointV1Dto.ChargePoint.Response>>() {
+                            });
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND),
+                    () -> assertThat(response.getBody()).isNotNull()
+            );
+        }
+    }
+}

--- a/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
+++ b/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
@@ -1,9 +1,9 @@
 package com.loopers.utils;
 
-import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.Type;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,17 +14,28 @@ import java.util.List;
 @Component
 public class DatabaseCleanUp implements InitializingBean {
 
+    private final List<String> tableNames = new ArrayList<>();
     @PersistenceContext
     private EntityManager entityManager;
-
-    private final List<String> tableNames = new ArrayList<>();
 
     @Override
     public void afterPropertiesSet() {
         entityManager.getMetamodel().getEntities().stream()
-            .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
-            .map(entity -> entity.getJavaType().getAnnotation(Table.class).name())
-            .forEach(tableNames::add);
+                .map(Type::getJavaType)
+                .map(this::resolveTableNameSafely)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .forEach(tableNames::add);
+    }
+
+    private String resolveTableNameSafely(Class<?> type) {
+        for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
+            Table t = c.getAnnotation(Table.class);
+            if (t != null && t.name() != null && !t.name().isBlank()) {
+                return t.name();
+            }
+        }
+        return null;
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 유저, 포인트 모델 분리하여 유저와 포인트가 함께 락 잡히는 것 방지
- 재고 동시성 이슈 비관적락으로 제어 [ProductStockJpaRepository.java:16](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-dcf728f82013974226d753a803b180892ee1b175e0f9d74b08ff00d9924aad7b)
- 포인트 동시성 이슈 비관적락으로 제어 [PointJpaRepository.java:17](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-e3944338808fd94b32c7019566bcefb5fd3f3d54825e1ccd258c52e9ed4334e3)
- 정률 할인, 정액 할인 쿠폰 single table inheritance로 구현 [Coupon.java:12](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-9b969f08db20cf40a482bf57db3c15cf1eccd38475f15959910a5706f82f51a7)
- 쿠폰 동시성 이슈 낙관적락으로 제어
- 상품 좋아요 카운트 동시성 이슈 증감 쿼리로 제어 [LikeProductCountJpaRepository.java:14](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-d1b21136d3804f11bc67455c5cbc0aa9247ed81486152930047dac1cfa060aeb)
- 트랜잭션으로 재고/포인트/쿠폰 정합성 보장
- 최소 품질 체크 리스트 만족하도록 쿼리 힌트 사용하여 비관적락 timeout 5초 적용 [PointJpaRepository.java:18](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-e3944338808fd94b32c7019566bcefb5fd3f3d54825e1ccd258c52e9ed4334e3)
- 도메인에서 HttpStatus 결정하지 않도록 표준 예외 사용
- 단일 조회 기능에서 `@Transactional` 제거하여 불필요한 쿼리 방지 [PointService.java:38](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-5619c04943ad2bb11bed5e34cf918326ad23bb9afad7a510c072b41b9228ce09)

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

### 동시성 제어
- 발급된 쿠폰은 1회 밖에 사용 못하는 자원이기 때문에 동시 요청에서 하나만 성공하고 모두 실패해야합니다. 따라서 낙관적락으로 구현했습니다.
- 포인트는 동시 요청에서 포인트가 충분하다면 모두 성공해야합니다. 따라서 비관적락으로 구현했습니다.
- 재고는 동시 요청에서 재고가 충분하다면 모두 성공해야합니다. 따라서 비관적락으로 구현했습니다.
- 상품 좋아요 카운트는 동시 요청에서 모두 성공해야합니다. 다만 특별한 validation이 필요하지 않고, 단순히 값을 1 증감 시키면 되는 케이스라서 락을 사용하지 않고 증감 쿼리를 작성하여 동시성 문제를 회피하였습니다. [LikeProductCountJpaRepository.java:14](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-d1b21136d3804f11bc67455c5cbc0aa9247ed81486152930047dac1cfa060aeb)

### 정률 할인, 정액 할인 쿠폰 구현
 쿠폰 할인 방식에 따라 테이블을 구분하면, 조회 수정 등의 로직이 모두 분리되어 복잡도가 올라갈 것으로 예상했습니다. 따라서 쿠폰 할인 방식에 따라 테이블을 구분하지 않고, 하나의 쿠폰 테이블을 사용하여 구현했습니다.

 하나의 테이블로 두개 이상의 할인 방식을 적용 시키는 방법으로 먼저 `할인 계산 로직을 별도의 클래스로 분리`를 고려하였으나,  할인 계산 로직이 도메인 클래스 밖으로 분리되는 것이 응집성을 떨어뜨리는 것으로 느껴졌습니다.

 `single table inheritance`을 사용해서 쿠폰을 추상 클래스 단일 테이블로 구현하고 이를 상속하는 다른 타입의 할인 쿠폰 클래스를 구현했습니다. 그 결과 계산 로직이 각 타입의 할인 쿠폰 클래스에 들어가 응집성이 올라갔습니다.

 대신 상속하여 구현한 할인 쿠폰 클래스에서는 `@Table(name = "coupon")`을 설정해줄 수 없었습니다. 그래서 DatabaseCleanUp에서 테이블명을 읽어오지 못하는 문제가 발생했습니다. 그래서 DatabaseCleanUp의 테이블명 스캔 로직을 수정하여 부모 클래스의 `@Table(name = "coupon")`까지 스캔하도록 수정하여 해결했습니다.

### single table inheritance의 장단점

 `single table inheritance`으로 할인 계산 로직이 다른 클래스를 구현하면서 느낀점은 좀 더 복잡한 케이스에 적절한 방법이라는 것입니다. 별도의 클래스로 구현하여 할인 계산 로직 뿐만 아니라 다른 로직들도 조금씩 달라지는 경우에 더 적합해 보였습니다. 그렇다고 모든 로직이 다른 경우는 별도의 테이블로 구현하는 것이 좋을 것 같습니다. 공통의 값을 가지고, 공통의 로직도 있지만, 타입에 따라 일부 로직이 달라지는 경우에 적절하다고 느껴졌습니다.

 멘토님은 실무에서 `single table inheritance`를 사용하시는지, 어떤 경우에 사용하시는지 궁금합니다.

### 불필요한 `@Transactional` 제거
 단일 조회 기능에서 `@Transactional` 제거하여 불필요한 쿼리 방지 [PointService.java:38](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-5619c04943ad2bb11bed5e34cf918326ad23bb9afad7a510c072b41b9228ce09) 를 적용했습니다.

 단일 수정에서도 불필요한 `@Transactional` 제거하기 위해서 해당하는 케이스를 찾아봤습니다. 상품 좋아요 카운트 동시성 이슈 증감 쿼리로 제어 [LikeProductCountJpaRepository.java:14](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-d1b21136d3804f11bc67455c5cbc0aa9247ed81486152930047dac1cfa060aeb) 이 로직이 단순 update 쿼리를 사용하는 것이라 불필요한 `@Transactional`이라 느껴졌습니다. 그런데 `@Transactional`을 제거하니 쿼리가 커밋되지 않았습니다.

 `@Transactional`이 끝날때 쿼리가 커밋되기 때문에 발생한 문제로 이해했습니다. 그렇다면 단일 수정은 커밋되기 위해서 `@Transactional`이 필수라고 생각됩니다. 그렇다면 단일 수정에서 `@Transactional`을 제거할 수 있는 케이스가 없다고 생각됩니다.

 단일 수정 로직에서 `@Transactional`을 제거하고 사용할 수 있는 예시가 어떤 것이 있는지 궁금합니다.


## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다. [CouponIssuanceTest.java:52](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-39b3e0e42b1334a8f51844d4c5b801bd883fa9b37a94074bc687930a91f3bd3b)
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다. [OrderFacadeIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다. [OrderFacadeIntegrationTest.java:161](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다. [OrderFacadeIntegrationTest.java:56](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다 [OrderFacadeIntegrationTest.java:108](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다. [OrderFacadeIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다. [OrderFacadeIntegrationTest.java:216](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-04a12bf0858eedbc43a02d4a10eaf5c1c660590f6b11d061bc905082d010758f)

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다. [LikeFacadeIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-c3bff578225c6649dcc7fbb9da027ff0c2d461f21b82e44ebb012faf62bc4c8c)
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다. [CouponServiceIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-dc51cfc95d53016476414e82ce5c8bd47469f9c52261df533b35a61b7afd62a3)
- [x]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다. [PointServiceIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-e38e40330711970878f530583f8d85b4d41a16f5f0cdc2d60c30a32c6a86c798)
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다. [ProductServiceIntegrationTest.java](https://github.com/Loopers-Team-6/hainho/pull/18/files#diff-f7cf5880afd6211320e569ed44e71dbcd191ffb42bfb6bb9d7f804367b60c053)