### PR TITLE
[round-9] 실시간 랭킹 파이프라인 구축

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -27,8 +27,8 @@ public class ProductFacade {
         ProductInfo.Get productInfo = productService.getProductInfo(productId, userId);
         BrandInfo.Get brandInfo = brandService.getBrandInfo(productInfo.brandId());
         LikeInfo.Get likeInfo = likeService.getLikeProductInfo(userId, productId);
-
-        return ProductResult.Get.Detail.from(productInfo, brandInfo, likeInfo);
+        Long ranking = rankingService.getRanking(productId).orElse(null);
+        return ProductResult.Get.Detail.from(productInfo, brandInfo, likeInfo, ranking);
     }
 
     public ProductResult.Get.Page getProductPage(Long userId, Long brandId, Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -6,10 +6,14 @@ import com.loopers.domain.like.LikeInfo;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.RankingInfo;
+import com.loopers.domain.ranking.RankingService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,6 +21,7 @@ public class ProductFacade {
     private final ProductService productService;
     private final BrandService brandService;
     private final LikeService likeService;
+    private final RankingService rankingService;
 
     public ProductResult.Get.Detail getProductDetail(Long userId, Long productId) {
         ProductInfo.Get productInfo = productService.getProductInfo(productId, userId);
@@ -28,5 +33,12 @@ public class ProductFacade {
 
     public ProductResult.Get.Page getProductPage(Long userId, Long brandId, Pageable pageable) {
         return ProductResult.Get.Page.from(productService.getProductPage(userId, brandId, pageable));
+    }
+
+    public ProductResult.Get.Page getProductRankingPage(Long userId, String date, Pageable pageable) {
+        RankingInfo.Get productRankingInfo = rankingService.getProductRanking(date, pageable);
+        Long totalCount = rankingService.getTotalCount(date);
+        List<ProductInfo.GetPage> productInfos = productService.getProductRankingPage(productRankingInfo, userId);
+        return ProductResult.Get.Page.from(productInfos, pageable, totalCount);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -19,15 +19,17 @@ public final class ProductResult {
                 String name,
                 String description,
                 Long price,
+                Long ranking,
                 Brand brand,
                 Like like
         ) {
-            public static Detail from(ProductInfo.Get productInfo, BrandInfo.Get brandInfo, LikeInfo.Get likeInfo) {
+            public static Detail from(ProductInfo.Get productInfo, BrandInfo.Get brandInfo, LikeInfo.Get likeInfo, Long ranking) {
                 return new Detail(
                         productInfo.id(),
                         productInfo.name(),
                         productInfo.description(),
                         productInfo.price(),
+                        ranking,
                         Brand.from(brandInfo),
                         Like.from(likeInfo)
                 );

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -5,6 +5,7 @@ import com.loopers.domain.like.LikeInfo;
 import com.loopers.domain.product.ProductInfo;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -62,6 +63,13 @@ public final class ProductResult {
         public record Page(
                 org.springframework.data.domain.Page<Product> products
         ) {
+            public static Page from(List<ProductInfo.GetPage> productInfos, Pageable pageable, Long totalCount) {
+                List<Product> products = productInfos.stream()
+                        .map(Product::from)
+                        .toList();
+                return new Page(new org.springframework.data.domain.PageImpl<>(products, pageable, totalCount));
+            }
+
             public static Page from(org.springframework.data.domain.Page<ProductInfo.GetPage> productInfoPage) {
                 List<Product> productList = productInfoPage.getContent().stream()
                         .map(Product::from)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -19,6 +19,9 @@ public class CouponService {
 
     @Transactional
     public Long useCoupon(Long couponIssuanceId, Long orderId, Long orderPrice) {
+        if (couponIssuanceId == null) {
+            return 0L;
+        }
         CouponIssuance couponIssuance = getCouponIssuance(couponIssuanceId);
 
         Long couponId = couponIssuance.getCouponId();

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -19,22 +19,23 @@ public class Order extends BaseEntity {
     private TotalPrice totalPrice;
     @Embedded
     private DiscountedPrice discountedPrice;
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private OrderStatus status;
     @Version
     private Long version;
 
-    private Order(Long userId, TotalPrice totalPrice) {
+    private Order(Long userId, TotalPrice totalPrice, DiscountedPrice discountedPrice) {
         if (userId == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "userId는 null일 수 없습니다.");
         }
         this.userId = userId;
         this.totalPrice = totalPrice;
+        this.discountedPrice = discountedPrice;
         this.status = OrderStatus.PENDING;
     }
 
     public static Order create(Long userId, Long totalPrice) {
-        return new Order(userId, TotalPrice.of(totalPrice));
+        return new Order(userId, TotalPrice.of(totalPrice), DiscountedPrice.of(totalPrice));
     }
 
     public void applyDiscount(Long discountingAmount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/vo/DiscountedPrice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/vo/DiscountedPrice.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.order.vo;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class DiscountedPrice {
     private static final Long MIN_VALUE = 0L;
 
+    @Column(name = "discounted_price")
     private final Long value;
 
     private DiscountedPrice(Long value) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -31,9 +31,9 @@ public class PaymentService {
     @Transactional
     public PaymentInfo.Get createPointPayment(PaymentCommand.Create command) {
         Payment payment = Payment.create(command);
-        paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
 
-        PointPaymentCreated event = PointPaymentCreated.from(payment, command.userId());
+        PointPaymentCreated event = PointPaymentCreated.from(savedPayment, command.userId());
         paymentEventPublisher.publish(event);
 
         return PaymentInfo.Get.from(payment);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository {
@@ -11,4 +12,6 @@ public interface ProductRepository {
     Optional<Product> find(Long productId);
 
     Page<ProductInfo.GetPage> getPage(Long userId, Long brandId, Pageable pageable);
+
+    List<ProductInfo.GetPage> getPage(List<Long> productIds, Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
@@ -2,10 +2,14 @@ package com.loopers.domain.ranking;
 
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRankingRepository {
-    List<RankingInfo.Get.Item> getRankingWithPagination(String key, Pageable pageable);
+    List<RankingInfo.Get.Item> getRankingWithPagination(String date, Pageable pageable);
 
     Long getTotalCount(String date);
+
+    Optional<Long> getRanking(LocalDate date, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ProductRankingRepository {
+    List<RankingInfo.Get.Item> getRankingWithPagination(String key, Pageable pageable);
+
+    Long getTotalCount(String date);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingInfo.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.ranking;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingInfo {
+    public record Get(
+            List<Item> items
+    ) {
+        public record Item(
+                Long id
+        ) {
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.ranking;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingService {
+    private final ProductRankingRepository productRankingRepository;
+
+    public RankingInfo.Get getProductRanking(String date, Pageable pageable) {
+        List<RankingInfo.Get.Item> items = productRankingRepository.getRankingWithPagination(date, pageable);
+        return new RankingInfo.Get(items);
+    }
+
+    public Long getTotalCount(String date) {
+        return productRankingRepository.getTotalCount(date);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -5,7 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,5 +22,10 @@ public class RankingService {
 
     public Long getTotalCount(String date) {
         return productRankingRepository.getTotalCount(date);
+    }
+
+    public Optional<Long> getRanking(Long productId) {
+        LocalDate curDate = ZonedDateTime.now().toLocalDate();
+        return productRankingRepository.getRanking(curDate, productId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,5 +51,16 @@ public class ProductRankingRedisRepository implements ProductRankingRepository {
 
     private String generateKey(String date) {
         return "rank:all:" + date;
+    }
+
+    @Override
+    public Optional<Long> getRanking(LocalDate date, Long productId) {
+        String key = generateKey(date.toString());
+        Long ranking = redisTemplate.opsForZSet().reverseRank(key, productId);
+        return Optional.ofNullable(toRanking(ranking));
+    }
+
+    private Long toRanking(Long ranking) {
+        return ranking == null ? null : ranking + 1;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -1,0 +1,53 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.ProductRankingRepository;
+import com.loopers.domain.ranking.RankingInfo;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductRankingRedisRepository implements ProductRankingRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public List<RankingInfo.Get.Item> getRankingWithPagination(String date, Pageable pageable) {
+        List<Object> rankingData = findRankingData(date, pageable);
+
+        if (rankingData.isEmpty()) {
+            return List.of();
+        }
+
+        return rankingData.stream()
+                .map(value -> new RankingInfo.Get.Item(
+                        Long.valueOf(value.toString())
+                ))
+                .toList();
+    }
+
+    private List<Object> findRankingData(String date, Pageable pageable) {
+        String key = generateKey(date);
+        long size = pageable.getPageSize();
+        long start = pageable.getOffset();
+        long end = start + size - 1;
+
+        var result = redisTemplate.opsForZSet().reverseRange(key, start, end);
+        return result == null ? List.of() : new ArrayList<>(result);
+    }
+
+    @Override
+    public Long getTotalCount(String date) {
+        String key = generateKey(date);
+        return redisTemplate.opsForZSet().size(key);
+    }
+
+    private String generateKey(String date) {
+        return "rank:all:" + date;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSepc.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSepc.java
@@ -46,4 +46,26 @@ public interface ProductV1ApiSepc {
             )
             Long userId
     );
+
+    @Operation(
+            summary = "상품 랭킹 조회",
+            description = "상품 랭킹 정보를 조회합니다."
+    )
+    ApiResponse<ProductV1Dto.GetProducts.Response> getProductRanking(
+            @Schema(
+                    name = "상품 랭킹 조회 요청",
+                    description = "상품 랭킹 조회에 필요한 정보를 담고 있는 요청 객체"
+            )
+            ProductV1Dto.GetProductRankings.Request request,
+            @Schema(
+                    name = "페이지 정보",
+                    description = "상품 목록을 조회할 때 사용할 페이지 정보"
+            )
+            Pageable pageable,
+            @Schema(
+                    name = "X-USER-ID",
+                    description = "조회할 사용자의 ID"
+            )
+            Long userId
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -37,4 +37,16 @@ public class ProductV1Controller implements ProductV1ApiSepc {
         ProductV1Dto.GetDetail.Response response = ProductV1Dto.GetDetail.Response.from(detail);
         return ApiResponse.success(response);
     }
+
+    @Override
+    @GetMapping("/rankings")
+    public ApiResponse<ProductV1Dto.GetProducts.Response> getProductRanking(
+            ProductV1Dto.GetProductRankings.Request request,
+            Pageable pageable,
+            @RequestHeader(value = "X-USER-ID", required = false) Long userId
+    ) {
+        ProductResult.Get.Page page = productFacade.getProductRankingPage(userId, request.date(), pageable);
+        ProductV1Dto.GetProducts.Response response = ProductV1Dto.GetProducts.Response.from(page, pageable);
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -84,6 +84,7 @@ public class ProductV1Dto {
                     Long id,
                     String name,
                     Long price,
+                    Long ranking,
                     Brand brand,
                     Like like,
                     String description
@@ -93,6 +94,7 @@ public class ProductV1Dto {
                             product.id(),
                             product.name(),
                             product.price(),
+                            product.ranking(),
                             Brand.from(product.brand()),
                             Like.from(product.like()),
                             product.description()

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -119,4 +119,12 @@ public class ProductV1Dto {
             }
         }
     }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetProductRankings {
+        public record Request(
+                String date
+        ) {
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/spring/point/PointEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/spring/point/PointEventHandler.java
@@ -4,6 +4,7 @@ import com.loopers.domain.payment.PointPaymentCreated;
 import com.loopers.domain.point.PointService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PointEventHandler {
     private final PointService pointService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PointPaymentCreated event) {
         pointService.usePoint(event.userId(), event.amount(), event.orderId(), event.paymentId());

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -9,28 +9,35 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RankingFacade {
+    private static final ZoneId ZONE_ID = ZoneId.systemDefault();
     private final ProductRankingService productRankingService;
 
+    private LocalDate toZoneDate(ZonedDateTime producedAt) {
+        return producedAt.withZoneSameInstant(ZONE_ID).toLocalDate();
+    }
+
     public void rankByViews(ProductFound event, ZonedDateTime producedAt) {
-        productRankingService.rankByViews(event.productId(), 1L, producedAt);
+        productRankingService.rankByViews(event.productId(), 1L, toZoneDate(producedAt));
     }
 
     public void rankByPurchases(OrderCompleted event, ZonedDateTime producedAt) {
         event.items().forEach(item ->
-                productRankingService.rankByPurchases(item.productId(), item.price(), item.quantity(), producedAt)
+                productRankingService.rankByPurchases(item.productId(), item.price(), item.quantity(), toZoneDate(producedAt))
         );
     }
 
     public void rankByLikes(LikeProductCreated event, ZonedDateTime producedAt) {
-        productRankingService.rankByLikes(event.productId(), 1L, producedAt);
+        productRankingService.rankByLikes(event.productId(), 1L, toZoneDate(producedAt));
     }
 
     public void rankByUnlikes(LikeProductDeleted event, ZonedDateTime producedAt) {
-        productRankingService.rankByLikes(event.productId(), -1L, producedAt);
+        productRankingService.rankByLikes(event.productId(), -1L, toZoneDate(producedAt));
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -117,6 +117,10 @@ public class RankingFacade {
     public void carryOverDailyRanking(LocalDate currentDate) {
         LocalDate nextDate = currentDate.plusDays(1);
         List<RankingInfo.WithScore> rankingInfos = productRankingService.getRankingAll(currentDate);
-        productRankingService.addRanking(nextDate, rankingInfos);
+        if (rankingInfos.isEmpty()) {
+            return;
+        }
+        List<RankingInfo.WithScore> normalizedRankingInfos = productRankingService.normalizeScore(rankingInfos);
+        productRankingService.addRanking(nextDate, normalizedRankingInfos);
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -33,9 +33,18 @@ public class RankingFacade {
     }
 
     public void rankByCatalogEvent(List<CatalogTopicMessage> messages) {
+        Map<LocalDate, List<CatalogTopicMessage>> messagesByDate = groupMessagesByDate(messages);
+        messagesByDate.forEach(this::rankByCatalogEventPerDate);
+    }
+
+    private void rankByCatalogEventPerDate(LocalDate date, List<CatalogTopicMessage> messages) {
         Map<Long, Double> productIdScoreMap = toProductIdScoreMapFromCatalogMessages(messages);
-        LocalDate producedDate = toZoneDate(messages.get(0).producedAt());
-        productRankingService.rank(productIdScoreMap, producedDate);
+        productRankingService.rank(productIdScoreMap, date);
+    }
+
+    private Map<LocalDate, List<CatalogTopicMessage>> groupMessagesByDate(List<CatalogTopicMessage> messages) {
+        return messages.stream()
+                .collect(Collectors.groupingBy(message -> toZoneDate(message.producedAt())));
     }
 
     private Map<Long, Double> toProductIdScoreMapFromCatalogMessages(List<CatalogTopicMessage> messages) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,10 +1,12 @@
 package com.loopers.application.ranking;
 
 import com.loopers.domain.ranking.ProductRankingService;
+import com.loopers.interfaces.consumer.events.catalog.CatalogTopicMessage;
 import com.loopers.interfaces.consumer.events.catalog.LikeProductCreated;
 import com.loopers.interfaces.consumer.events.catalog.LikeProductDeleted;
 import com.loopers.interfaces.consumer.events.catalog.ProductFound;
 import com.loopers.interfaces.consumer.events.order.OrderCompleted;
+import com.loopers.interfaces.consumer.events.order.OrderTopicMessage;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,6 +14,10 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,21 +29,87 @@ public class RankingFacade {
         return producedAt.withZoneSameInstant(ZONE_ID).toLocalDate();
     }
 
-    public void rankByViews(ProductFound event, ZonedDateTime producedAt) {
-        productRankingService.rankByViews(event.productId(), 1L, toZoneDate(producedAt));
+    public void rankByCatalogEvent(List<CatalogTopicMessage> messages) {
+        Map<Long, Double> productIdScoreMap = toProductIdScoreMapFromCatalogMessages(messages);
+        LocalDate producedDate = toZoneDate(messages.get(0).producedAt());
+        productRankingService.rank(productIdScoreMap, producedDate);
     }
 
-    public void rankByPurchases(OrderCompleted event, ZonedDateTime producedAt) {
-        event.items().forEach(item ->
-                productRankingService.rankByPurchases(item.productId(), item.price(), item.quantity(), toZoneDate(producedAt))
-        );
+    private Map<Long, Double> toProductIdScoreMapFromCatalogMessages(List<CatalogTopicMessage> messages) {
+        List<ProductFound> productFoundEvents = messages.stream()
+                .map(CatalogTopicMessage::payload)
+                .filter(ProductFound.class::isInstance)
+                .map(ProductFound.class::cast)
+                .toList();
+
+        List<LikeProductCreated> likeCreatedEvents = messages.stream()
+                .map(CatalogTopicMessage::payload)
+                .filter(LikeProductCreated.class::isInstance)
+                .map(LikeProductCreated.class::cast)
+                .toList();
+
+        List<LikeProductDeleted> likeDeletedEvents = messages.stream()
+                .map(CatalogTopicMessage::payload)
+                .filter(LikeProductDeleted.class::isInstance)
+                .map(LikeProductDeleted.class::cast)
+                .toList();
+
+        Map<Long, Double> productIdScoreMap = new HashMap<>();
+
+        productFoundEvents.stream()
+                .collect(Collectors.groupingBy(
+                        ProductFound::productId,
+                        Collectors.counting()
+                ))
+                .forEach((productId, count) -> {
+                    double score = productRankingService.calculateScoreByView(count);
+                    productIdScoreMap.merge(productId, score, Double::sum);
+                });
+
+        likeCreatedEvents.stream()
+                .collect(Collectors.groupingBy(
+                        LikeProductCreated::productId,
+                        Collectors.counting()
+                ))
+                .forEach((productId, count) -> {
+                    double score = productRankingService.calculateScoreByLikeCreated(count);
+                    productIdScoreMap.merge(productId, score, Double::sum);
+                });
+
+        likeDeletedEvents.stream()
+                .collect(Collectors.groupingBy(
+                        LikeProductDeleted::productId,
+                        Collectors.counting()
+                ))
+                .forEach((productId, count) -> {
+                    double score = productRankingService.calculateScoreByLikeDeleted(count);
+                    productIdScoreMap.merge(productId, score, Double::sum);
+                });
+
+        return productIdScoreMap;
     }
 
-    public void rankByLikes(LikeProductCreated event, ZonedDateTime producedAt) {
-        productRankingService.rankByLikes(event.productId(), 1L, toZoneDate(producedAt));
+    public void rankByOrderEvent(List<OrderTopicMessage> messages) {
+        Map<Long, Double> productIdScoreMap = toProductIdScoreMapFromOrderMessages(messages);
+        LocalDate producedDate = toZoneDate(messages.get(0).producedAt());
+        productRankingService.rank(productIdScoreMap, producedDate);
     }
 
-    public void rankByUnlikes(LikeProductDeleted event, ZonedDateTime producedAt) {
-        productRankingService.rankByLikes(event.productId(), -1L, toZoneDate(producedAt));
+    private Map<Long, Double> toProductIdScoreMapFromOrderMessages(List<OrderTopicMessage> messages) {
+        List<OrderCompleted> orderCompletedEvents =
+                messages.stream()
+                        .map(OrderTopicMessage::payload)
+                        .filter(OrderCompleted.class::isInstance)
+                        .map(OrderCompleted.class::cast)
+                        .toList();
+
+        return orderCompletedEvents.stream()
+                .flatMap(order -> order.items().stream())
+                .collect(
+                        Collectors.groupingBy(
+                                OrderCompleted.OrderItem::productId,
+                                Collectors.summingDouble(item -> productRankingService.calculateScoreByPriceAndAmount(item.price(), item.quantity()))
+                        )
+                );
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,6 +1,7 @@
 package com.loopers.application.ranking;
 
 import com.loopers.domain.ranking.ProductRankingService;
+import com.loopers.domain.ranking.RankingInfo;
 import com.loopers.interfaces.consumer.events.catalog.CatalogTopicMessage;
 import com.loopers.interfaces.consumer.events.catalog.LikeProductCreated;
 import com.loopers.interfaces.consumer.events.catalog.LikeProductDeleted;
@@ -111,5 +112,11 @@ public class RankingFacade {
                                 Collectors.summingDouble(item -> productRankingService.calculateScoreByPriceAndAmount(item.price(), item.quantity()))
                         )
                 );
+    }
+
+    public void carryOverDailyRanking(LocalDate currentDate) {
+        LocalDate nextDate = currentDate.plusDays(1);
+        List<RankingInfo.WithScore> rankingInfos = productRankingService.getRankingAll(currentDate);
+        productRankingService.addRanking(nextDate, rankingInfos);
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,36 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.ProductRankingService;
+import com.loopers.interfaces.consumer.events.catalog.LikeProductCreated;
+import com.loopers.interfaces.consumer.events.catalog.LikeProductDeleted;
+import com.loopers.interfaces.consumer.events.catalog.ProductFound;
+import com.loopers.interfaces.consumer.events.order.OrderCompleted;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingFacade {
+    private final ProductRankingService productRankingService;
+
+    public void rankByViews(ProductFound event, ZonedDateTime producedAt) {
+        productRankingService.rankByViews(event.productId(), 1L, producedAt);
+    }
+
+    public void rankByPurchases(OrderCompleted event, ZonedDateTime producedAt) {
+        event.items().forEach(item ->
+                productRankingService.rankByPurchases(item.productId(), item.price(), item.quantity(), producedAt)
+        );
+    }
+
+    public void rankByLikes(LikeProductCreated event, ZonedDateTime producedAt) {
+        productRankingService.rankByLikes(event.productId(), 1L, producedAt);
+    }
+
+    public void rankByUnlikes(LikeProductDeleted event, ZonedDateTime producedAt) {
+        productRankingService.rankByLikes(event.productId(), -1L, producedAt);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
@@ -1,7 +1,8 @@
 package com.loopers.domain.ranking;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 public interface ProductRankingRepository {
-    void incrementScore(Long productId, double score, LocalDate actionDate);
+    void incrementScore(Map<Long, Double> productIdScoreMap, LocalDate actionDate);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
@@ -1,8 +1,13 @@
 package com.loopers.domain.ranking;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 public interface ProductRankingRepository {
     void incrementScore(Map<Long, Double> productIdScoreMap, LocalDate actionDate);
+
+    List<RankingInfo.WithScore> getRankingAllWithScore(LocalDate date);
+
+    void addRanking(LocalDate date, List<RankingInfo.WithScore> rankingInfos);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+
+public interface ProductRankingRepository {
+    void incrementScore(Long productId, double score, LocalDate actionDate);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Component
@@ -17,9 +17,9 @@ public class ProductRankingService {
     private final RankingWeightRepository rankingWeightRepository;
     private final ProductRankingRepository productRankingRepository;
 
-    public void rankByViews(Long productId, Long views, ZonedDateTime producedAt) {
+    public void rankByViews(Long productId, Long views, LocalDate rankDate) {
         double score = calculateScoreByView(views);
-        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+        productRankingRepository.incrementScore(productId, score, rankDate);
     }
 
     private double calculateScoreByView(Long views) {
@@ -27,9 +27,9 @@ public class ProductRankingService {
         return views * weight;
     }
 
-    public void rankByPurchases(Long productId, Long price, Long amount, ZonedDateTime producedAt) {
+    public void rankByPurchases(Long productId, Long price, Long amount, LocalDate rankDate) {
         double score = calculateScoreByPriceAndAmount(price, amount);
-        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+        productRankingRepository.incrementScore(productId, score, rankDate);
     }
 
     private double calculateScoreByPriceAndAmount(Long price, Long amount) {
@@ -37,9 +37,9 @@ public class ProductRankingService {
         return (price * amount) * weight;
     }
 
-    public void rankByLikes(Long productId, Long likes, ZonedDateTime producedAt) {
+    public void rankByLikes(Long productId, Long likes, LocalDate rankDate) {
         double score = calculateScoreByLike(likes);
-        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+        productRankingRepository.incrementScore(productId, score, rankDate);
     }
 
     private double calculateScoreByLike(Long likes) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -57,5 +58,13 @@ public class ProductRankingService {
 
     public void rank(Map<Long, Double> productIdScoreMap, LocalDate producedDate) {
         productRankingRepository.incrementScore(productIdScoreMap, producedDate);
+    }
+
+    public List<RankingInfo.WithScore> getRankingAll(LocalDate date) {
+        return productRankingRepository.getRankingAllWithScore(date);
+    }
+
+    public void addRanking(LocalDate date, List<RankingInfo.WithScore> rankingInfos) {
+        productRankingRepository.addRanking(date, rankingInfos);
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
@@ -1,0 +1,61 @@
+package com.loopers.domain.ranking;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductRankingService {
+    private static final double DEFAULT_VIEW_WEIGHT = 0.05;
+    private static final double DEFAULT_PURCHASE_WEIGHT = 1.0;
+    private static final double DEFAULT_LIKE_WEIGHT = 0.25;
+
+    private final RankingWeightRepository rankingWeightRepository;
+    private final ProductRankingRepository productRankingRepository;
+
+    public void rankByViews(Long productId, Long views, ZonedDateTime producedAt) {
+        double score = calculateScoreByView(views);
+        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+    }
+
+    private double calculateScoreByView(Long views) {
+        double weight = getWeight(WeightType.VIEW);
+        return views * weight;
+    }
+
+    public void rankByPurchases(Long productId, Long price, Long amount, ZonedDateTime producedAt) {
+        double score = calculateScoreByPriceAndAmount(price, amount);
+        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+    }
+
+    private double calculateScoreByPriceAndAmount(Long price, Long amount) {
+        double weight = getWeight(WeightType.PURCHASE);
+        return (price * amount) * weight;
+    }
+
+    public void rankByLikes(Long productId, Long likes, ZonedDateTime producedAt) {
+        double score = calculateScoreByLike(likes);
+        productRankingRepository.incrementScore(productId, score, producedAt.toLocalDate());
+    }
+
+    private double calculateScoreByLike(Long likes) {
+        double weight = getWeight(WeightType.LIKE);
+        return likes * weight;
+    }
+
+    private double getWeight(WeightType weightType) {
+        Optional<RankingWeight> optionalWeight = rankingWeightRepository.findFirstByTypeAndWeightTypeOrderByCreatedAtDesc(RankingTargetType.PRODUCT, weightType);
+        if (optionalWeight.isEmpty()) {
+            return switch (weightType) {
+                case VIEW -> DEFAULT_VIEW_WEIGHT;
+                case PURCHASE -> DEFAULT_PURCHASE_WEIGHT;
+                case LIKE -> DEFAULT_LIKE_WEIGHT;
+            };
+        }
+        return optionalWeight.get().getWeight();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/ProductRankingService.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductRankingService {
-    private static final double DEFAULT_VIEW_WEIGHT = 0.05;
-    private static final double DEFAULT_PURCHASE_WEIGHT = 1.0;
-    private static final double DEFAULT_LIKE_WEIGHT = 0.25;
+    private static final double DEFAULT_VIEW_WEIGHT = 0.1;
+    private static final double DEFAULT_PURCHASE_WEIGHT = 0.01;
+    private static final double DEFAULT_LIKE_WEIGHT = 1.0;
     private static final double SCORE_CAP = 0.05;
 
     // 기준가격(원)

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingInfo.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingInfo.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.ranking;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingInfo {
+    public record WithScore(
+            Long productId,
+            Double score
+    ) {
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingTargetType.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingTargetType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.ranking;
+
+public enum RankingTargetType {
+    PRODUCT
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ranking_weight")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class RankingWeight extends BaseEntity {
+    @Enumerated(EnumType.STRING)
+    private RankingTargetType type;
+
+    @Enumerated(EnumType.STRING)
+    private WeightType weightType;
+
+    private Double weight;
+
+    private RankingWeight(RankingTargetType type, WeightType weightType, double weight) {
+        this.type = type;
+        this.weightType = weightType;
+        this.weight = weight;
+    }
+
+    public static RankingWeight of(RankingTargetType type, WeightType weightType, Double weight) {
+        return new RankingWeight(type, weightType, weight);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeightRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.ranking;
+
+import java.util.Optional;
+
+public interface RankingWeightRepository {
+    RankingWeight save(RankingWeight rankingWeight);
+
+    Optional<RankingWeight> findFirstByTypeAndWeightTypeOrderByCreatedAtDesc(
+            RankingTargetType type, WeightType weightType);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/WeightType.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/WeightType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public enum WeightType {
+    VIEW,
+    PURCHASE,
+    LIKE
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Map;
+
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,8 +22,10 @@ public class ProductRankingRedisRepository implements ProductRankingRepository {
     }
 
     @Override
-    public void incrementScore(Long productId, double score, LocalDate actionedAt) {
+    public void incrementScore(Map<Long, Double> productIdScoreMap, LocalDate actionedAt) {
         String rankingKey = generateKey(actionedAt);
-        redisTemplate.opsForZSet().incrementScore(rankingKey, productId, score);
+        productIdScoreMap.forEach((productId, score) -> {
+            redisTemplate.opsForZSet().incrementScore(rankingKey, productId, score);
+        });
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -1,15 +1,17 @@
 package com.loopers.infrastructure.ranking;
 
 import com.loopers.domain.ranking.ProductRankingRepository;
+import com.loopers.domain.ranking.RankingInfo;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Component
@@ -35,9 +37,39 @@ public class ProductRankingRedisRepository implements ProductRankingRepository {
             public <K, V> Object execute(RedisOperations<K, V> operations) {
                 RedisOperations<String, Object> ops = (RedisOperations<String, Object>) operations;
                 productIdScoreMap.forEach((productId, score) ->
-                        ops.opsForZSet().incrementScore(rankingKey, productId.toString(), score));
+                        ops.opsForZSet().incrementScore(rankingKey, productId, score));
                 return null;
             }
         });
+    }
+
+    @Override
+    public List<RankingInfo.WithScore> getRankingAllWithScore(LocalDate date) {
+        String key = generateKey(date);
+        Set<ZSetOperations.TypedTuple<Object>> rankingTuples = redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, -1);
+        if (rankingTuples == null) {
+            return List.of();
+        }
+        return toRankingInfoList(rankingTuples);
+    }
+
+    private List<RankingInfo.WithScore> toRankingInfoList(Set<ZSetOperations.TypedTuple<Object>> rankingTuples) {
+        return rankingTuples.stream()
+                .map(tuple -> new RankingInfo.WithScore(
+                        Long.valueOf(tuple.getValue().toString()),
+                        tuple.getScore()))
+                .toList();
+    }
+
+    @Override
+    public void addRanking(LocalDate date, List<RankingInfo.WithScore> rankingInfos) {
+        String rankingKey = generateKey(date);
+        redisTemplate.opsForZSet().add(rankingKey, toTypedTuples(rankingInfos));
+    }
+
+    private Set<ZSetOperations.TypedTuple<Object>> toTypedTuples(List<RankingInfo.WithScore> rankingInfos) {
+        return rankingInfos.stream()
+                .map(info -> new DefaultTypedTuple<>((Object) info.productId(), info.score()))
+                .collect(Collectors.toSet());
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.ProductRankingRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductRankingRedisRepository implements ProductRankingRepository {
+    private static final String PRODUCT_RANKING_KEY_PREFIX = "rank:all:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private String generateKey(LocalDate actionedAt) {
+        return PRODUCT_RANKING_KEY_PREFIX + actionedAt.toString();
+    }
+
+    @Override
+    public void incrementScore(Long productId, double score, LocalDate actionedAt) {
+        String rankingKey = generateKey(actionedAt);
+        redisTemplate.opsForZSet().incrementScore(rankingKey, productId, score);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/ProductRankingRedisRepository.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductRankingRedisRepository implements ProductRankingRepository {
     private static final String PRODUCT_RANKING_KEY_PREFIX = "rank:all:";
+    private static final Duration RANKING_KEY_EXPIRE_DURATION = Duration.ofDays(2);
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -65,6 +67,7 @@ public class ProductRankingRedisRepository implements ProductRankingRepository {
     public void addRanking(LocalDate date, List<RankingInfo.WithScore> rankingInfos) {
         String rankingKey = generateKey(date);
         redisTemplate.opsForZSet().add(rankingKey, toTypedTuples(rankingInfos));
+        redisTemplate.expire(rankingKey, RANKING_KEY_EXPIRE_DURATION);
     }
 
     private Set<ZSetOperations.TypedTuple<Object>> toTypedTuples(List<RankingInfo.WithScore> rankingInfos) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingTargetType;
+import com.loopers.domain.ranking.RankingWeight;
+import com.loopers.domain.ranking.WeightType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RankingWeightJpaRepository extends JpaRepository<RankingWeight, Long> {
+    RankingWeight save(RankingWeight rankingWeight);
+
+    Optional<RankingWeight> findFirstByTypeAndWeightTypeOrderByCreatedAtDesc(
+            RankingTargetType type, WeightType weightType);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRedisRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRedisRepository.java
@@ -1,0 +1,42 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingTargetType;
+import com.loopers.domain.ranking.RankingWeight;
+import com.loopers.domain.ranking.WeightType;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingWeightRedisRepository {
+    private static final String KEY_PREFIX = "ranking_weight:";
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void save(RankingTargetType type, WeightType weightType, RankingWeight rankingWeight) {
+        String key = buildKey(type, weightType);
+        redisTemplate.opsForValue().set(key, rankingWeight);
+        Date tomorrowDate = getTomorrowDate();
+        redisTemplate.expireAt(key, tomorrowDate);
+    }
+
+    private String buildKey(RankingTargetType type, WeightType weightType) {
+        return KEY_PREFIX + type.name() + ":" + weightType.name();
+    }
+
+    private Date getTomorrowDate() {
+        ZonedDateTime tomorrow = ZonedDateTime.now().plusDays(1);
+        return Date.from(tomorrow.toInstant());
+    }
+
+    public Optional<RankingWeight> findWeight(RankingTargetType type, WeightType weightType) {
+        String key = buildKey(type, weightType);
+        RankingWeight rankingWeight = (RankingWeight) redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(rankingWeight);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingWeightRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingTargetType;
+import com.loopers.domain.ranking.RankingWeight;
+import com.loopers.domain.ranking.RankingWeightRepository;
+import com.loopers.domain.ranking.WeightType;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingWeightRepositoryImpl implements RankingWeightRepository {
+    private final RankingWeightJpaRepository rankingWeightJpaRepository;
+
+    @Override
+    public Optional<RankingWeight> findFirstByTypeAndWeightTypeOrderByCreatedAtDesc(RankingTargetType type, WeightType weightType) {
+        return rankingWeightJpaRepository.findFirstByTypeAndWeightTypeOrderByCreatedAtDesc(type, weightType);
+    }
+
+    @Override
+    public RankingWeight save(RankingWeight rankingWeight) {
+        return rankingWeightJpaRepository.save(rankingWeight);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/events/catalog/CatalogTopicMessage.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/events/catalog/CatalogTopicMessage.java
@@ -3,10 +3,12 @@ package com.loopers.interfaces.consumer.events.catalog;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.loopers.interfaces.consumer.events.KafkaMessage;
 
+import java.time.ZonedDateTime;
+
 public record CatalogTopicMessage(
         String eventId,
         String eventType,
-        java.time.ZonedDateTime producedAt,
+        ZonedDateTime producedAt,
         @JsonTypeInfo(
                 use = JsonTypeInfo.Id.NAME,
                 include = JsonTypeInfo.As.EXTERNAL_PROPERTY,

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
@@ -1,0 +1,58 @@
+package com.loopers.interfaces.consumer.ranking;
+
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.confg.kafka.KafkaTopics;
+import com.loopers.interfaces.consumer.events.catalog.CatalogTopicMessage;
+import com.loopers.interfaces.consumer.events.catalog.LikeProductCreated;
+import com.loopers.interfaces.consumer.events.catalog.LikeProductDeleted;
+import com.loopers.interfaces.consumer.events.catalog.ProductFound;
+import com.loopers.interfaces.consumer.events.order.OrderCompleted;
+import com.loopers.interfaces.consumer.events.order.OrderTopicMessage;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingConsumer {
+    private final RankingFacade rankingFacade;
+
+    @KafkaListener(
+            topics = {KafkaTopics.ORDER},
+            groupId = RankingKafkaConfig.RANKING_GROUP,
+            containerFactory = RankingKafkaConfig.RANKING_LISTENER
+    )
+    public void consumeOrderTopicEvent(List<OrderTopicMessage> messages, Acknowledgment acknowledgment) {
+        for (OrderTopicMessage message : messages) {
+            switch (message.payload()) {
+                case OrderCompleted event -> rankingFacade.rankByPurchases(event, message.producedAt());
+                default -> {
+                }
+            }
+        }
+        acknowledgment.acknowledge();
+    }
+
+
+    @KafkaListener(
+            topics = {KafkaTopics.CATALOG},
+            groupId = RankingKafkaConfig.RANKING_GROUP,
+            containerFactory = RankingKafkaConfig.RANKING_LISTENER
+    )
+    public void consumeCatalogTopicEvent(List<CatalogTopicMessage> messages, Acknowledgment acknowledgment) {
+        for (CatalogTopicMessage message : messages) {
+            switch (message.payload()) {
+                case LikeProductCreated event -> rankingFacade.rankByLikes(event, message.producedAt());
+                case LikeProductDeleted event -> rankingFacade.rankByUnlikes(event, message.producedAt());
+                case ProductFound event -> rankingFacade.rankByViews(event, message.producedAt());
+                default -> {
+                }
+            }
+        }
+        acknowledgment.acknowledge();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
@@ -26,12 +26,15 @@ public class RankingConsumer {
             groupId = RankingCriticalKafkaConfig.RANKING_CRITICAL_GROUP,
             containerFactory = RankingCriticalKafkaConfig.RANKING_CRITICAL_LISTENER
     )
-    public void consumeOrderTopicEvent(OrderTopicMessage message, Acknowledgment acknowledgment) {
-        if (!(message.payload() instanceof OrderCompleted)) {
+    public void consumeOrderTopicEvent(List<OrderTopicMessage> messages, Acknowledgment acknowledgment) {
+        List<OrderTopicMessage> orderTopicMessages = messages.stream()
+                .filter(message -> message.payload() instanceof OrderCompleted)
+                .toList();
+        if (orderTopicMessages.isEmpty()) {
             acknowledgment.acknowledge();
             return;
         }
-        rankingFacade.rankByOrderEvent(message, RankingCriticalKafkaConfig.RANKING_CRITICAL_GROUP);
+        rankingFacade.rankByOrderEvent(orderTopicMessages);
         acknowledgment.acknowledge();
     }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
@@ -14,7 +14,6 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 
 @Component
@@ -53,7 +52,6 @@ public class RankingConsumer {
             return;
         }
         rankingFacade.rankByCatalogEvent(messages);
-        rankingFacade.carryOverDailyRanking(ZonedDateTime.now().toLocalDate());
         acknowledgment.acknowledge();
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
@@ -14,6 +14,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Component
@@ -52,6 +53,7 @@ public class RankingConsumer {
             return;
         }
         rankingFacade.rankByCatalogEvent(messages);
+        rankingFacade.carryOverDailyRanking(ZonedDateTime.now().toLocalDate());
         acknowledgment.acknowledge();
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingConsumer.java
@@ -23,16 +23,15 @@ public class RankingConsumer {
 
     @KafkaListener(
             topics = {KafkaTopics.ORDER},
-            groupId = RankingKafkaConfig.RANKING_GROUP,
-            containerFactory = RankingKafkaConfig.RANKING_LISTENER
+            groupId = RankingCriticalKafkaConfig.RANKING_CRITICAL_GROUP,
+            containerFactory = RankingCriticalKafkaConfig.RANKING_CRITICAL_LISTENER
     )
-    public void consumeOrderTopicEvent(List<OrderTopicMessage> messages, Acknowledgment acknowledgment) {
-        List<OrderTopicMessage> orderCompletedMessages = messages.stream().filter(message -> message.payload() instanceof OrderCompleted).toList();
-        if (orderCompletedMessages.isEmpty()) {
+    public void consumeOrderTopicEvent(OrderTopicMessage message, Acknowledgment acknowledgment) {
+        if (!(message.payload() instanceof OrderCompleted)) {
             acknowledgment.acknowledge();
             return;
         }
-        rankingFacade.rankByOrderEvent(orderCompletedMessages);
+        rankingFacade.rankByOrderEvent(message, RankingCriticalKafkaConfig.RANKING_CRITICAL_GROUP);
         acknowledgment.acknowledge();
     }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingCriticalKafkaConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingCriticalKafkaConfig.java
@@ -9,6 +9,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
 
 import java.util.HashMap;
@@ -20,6 +21,9 @@ public class RankingCriticalKafkaConfig {
     public static final String RANKING_CRITICAL_CONSUMER_FACTORY = "rankingCriticalConsumerFactory";
     public static final String RANKING_CRITICAL_GROUP = "ranking-critical-group";
 
+    public static final int MAX_POLLING_SIZE = 500; // read 3000 msg
+    public static final int FETCH_MIN_BYTES = (256 * 1024); // 256kb
+    public static final int FETCH_MAX_WAIT_MS = 5 * 1000; // broker waiting time = 5s
     public static final int SESSION_TIMEOUT_MS = 60 * 1000; // session timeout = 1m
     public static final int HEARTBEAT_INTERVAL_MS = 20 * 1000; // heartbeat interval = 20s ( 1/3 of session_timeout )
     public static final int MAX_POLL_INTERVAL_MS = 2 * 60 * 1000; // max poll interval = 2m
@@ -27,7 +31,7 @@ public class RankingCriticalKafkaConfig {
     @Bean(RANKING_CRITICAL_CONSUMER_FACTORY)
     public ConsumerFactory<Object, Object> rankingConsumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 
@@ -37,6 +41,9 @@ public class RankingCriticalKafkaConfig {
             ByteArrayJsonMessageConverter converter
     ) {
         Map<String, Object> consumerConfig = new HashMap<>(rankingConsumerFactory.getConfigurationProperties());
+        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLLING_SIZE);
+        consumerConfig.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES);
+        consumerConfig.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, FETCH_MAX_WAIT_MS);
         consumerConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
         consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
         consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
@@ -44,9 +51,9 @@ public class RankingCriticalKafkaConfig {
         ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-        factory.setRecordMessageConverter(converter);
+        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter));
         factory.setConcurrency(3);
-        factory.setBatchListener(false);
+        factory.setBatchListener(true);
         return factory;
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingCriticalKafkaConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingCriticalKafkaConfig.java
@@ -9,41 +9,34 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
-public class RankingKafkaConfig {
-    public static final String RANKING_LISTENER = "rankingListener";
-    public static final String RANKING_CONSUMER_FACTORY = "rankingConsumerFactory";
-    public static final String RANKING_GROUP = "ranking-group";
+public class RankingCriticalKafkaConfig {
+    public static final String RANKING_CRITICAL_LISTENER = "rankingCriticalListener";
+    public static final String RANKING_CRITICAL_CONSUMER_FACTORY = "rankingCriticalConsumerFactory";
+    public static final String RANKING_CRITICAL_GROUP = "ranking-critical-group";
 
-    public static final int MAX_POLLING_SIZE = 3000; // read 3000 msg
-    public static final int FETCH_MIN_BYTES = (1024 * 1024); // 1mb
-    public static final int FETCH_MAX_WAIT_MS = 5 * 1000; // broker waiting time = 5s
     public static final int SESSION_TIMEOUT_MS = 60 * 1000; // session timeout = 1m
     public static final int HEARTBEAT_INTERVAL_MS = 20 * 1000; // heartbeat interval = 20s ( 1/3 of session_timeout )
     public static final int MAX_POLL_INTERVAL_MS = 2 * 60 * 1000; // max poll interval = 2m
 
-    @Bean(RANKING_CONSUMER_FACTORY)
+    @Bean(RANKING_CRITICAL_CONSUMER_FACTORY)
     public ConsumerFactory<Object, Object> rankingConsumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 
-    @Bean(name = RANKING_LISTENER)
+    @Bean(name = RANKING_CRITICAL_LISTENER)
     public ConcurrentKafkaListenerContainerFactory<Object, Object> rankingListenerContainerFactory(
-            @Qualifier(RANKING_CONSUMER_FACTORY) ConsumerFactory<Object, Object> rankingConsumerFactory,
+            @Qualifier(RANKING_CRITICAL_CONSUMER_FACTORY) ConsumerFactory<Object, Object> rankingConsumerFactory,
             ByteArrayJsonMessageConverter converter
     ) {
         Map<String, Object> consumerConfig = new HashMap<>(rankingConsumerFactory.getConfigurationProperties());
-        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLLING_SIZE);
-        consumerConfig.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES);
-        consumerConfig.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, FETCH_MAX_WAIT_MS);
         consumerConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
         consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
         consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
@@ -51,9 +44,9 @@ public class RankingKafkaConfig {
         ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter));
+        factory.setRecordMessageConverter(converter);
         factory.setConcurrency(3);
-        factory.setBatchListener(true);
+        factory.setBatchListener(false);
         return factory;
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingKafkaConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingKafkaConfig.java
@@ -1,0 +1,53 @@
+package com.loopers.interfaces.consumer.ranking;
+
+import com.loopers.confg.kafka.KafkaConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class RankingKafkaConfig {
+    public static final String RANKING_LISTENER = "rankingListener";
+    public static final String RANKING_CONSUMER_FACTORY = "rankingConsumerFactory";
+    public static final String RANKING_GROUP = "ranking-group";
+
+    @Bean(RANKING_CONSUMER_FACTORY)
+    public ConsumerFactory<Object, Object> rankingConsumerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean(name = RANKING_LISTENER)
+    public ConcurrentKafkaListenerContainerFactory<Object, Object> rankingListenerContainerFactory(
+            @Qualifier(RANKING_CONSUMER_FACTORY) ConsumerFactory<Object, Object> rankingConsumerFactory,
+            ByteArrayJsonMessageConverter converter
+    ) {
+        Map<String, Object> consumerConfig = new HashMap<>(rankingConsumerFactory.getConfigurationProperties());
+        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, KafkaConfig.MAX_POLLING_SIZE);
+        consumerConfig.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, KafkaConfig.FETCH_MIN_BYTES);
+        consumerConfig.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, KafkaConfig.FETCH_MAX_WAIT_MS);
+        consumerConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, KafkaConfig.SESSION_TIMEOUT_MS);
+        consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, KafkaConfig.HEARTBEAT_INTERVAL_MS);
+        consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, KafkaConfig.MAX_POLL_INTERVAL_MS);
+
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter));
+        factory.setConcurrency(3);
+        factory.setBatchListener(true);
+        return factory;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/spring/ranking/RankingScheduler.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/spring/ranking/RankingScheduler.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.spring.ranking;
+
+import com.loopers.application.ranking.RankingFacade;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingScheduler {
+    private final RankingFacade rankingFacade;
+
+    @Scheduled(cron = "0 50 23 * * *", zone = "Asia/Seoul")
+    public void carryOverDailyRanking() {
+        rankingFacade.carryOverDailyRanking(ZonedDateTime.now().toLocalDate());
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 유저 시그널 기반으로 상품 랭킹 스코어 반영하는 랭킹 컨슈머 구현 [RankingConsumer.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-b883e40547a13eb23a527503b7779505235ef3565c8ab57f943f382e8e684077)
- 일간 상품 랭킹 조회 API 구현 [ProductV1Controller.java:41](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-0803cdd569d855b62ea6b25fff9ba6aff99405b2071e9991f9626aa61177d858)
- 상품 상세 조회 시 랭킹 정보 응답 추가 [ProductFacade.java:30](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-202b7e784888378b834b210bd023b39df353ca164c8f48fec82a71cf023c8ec6)
- score carry over를 통한 일간 랭킹 콜드 스타드 방지 구현 [RankingScheduler.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-ee6a8b372e14e55f5ff9396685c57fa31ba61d279872ac8a8ee93d36749b04a8)
- 실시간 Weight 조절을 위한 RankingWeight 엔티티 구현 [RankingWeight.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-c6aebc7ce22d03498e8a695e3c95abb8d4793a9f8115eba64c3e289101e8226b)

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

---

###  상품 조회, 상품 좋아요 랭킹 스코어 반영 [RankingConsumer.java:38](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-b883e40547a13eb23a527503b7779505235ef3565c8ab57f943f382e8e684077)
 상품 조회, 상품 좋아요 이벤트는 빈도수가 매우 높은 이벤트입니다. 따라서 IO, DB 연산, Redis 연산 횟수를 최소화 해야 합니다. 또한 누락이 발생해도 큰 문제가 없으며, lag를 줄이는 것이 우선됩니다.

1. 배치 리스너 사용
2. offset reset 방식 latest
3. 멱등 처리 제외
4. product id 기준으로 groupping
5. redis zset에 score 반영 시 RTT 최소화를 위한 executePipelined 사용

 추가로 배치로 읽어온 메시지들에 날짜가 다른 이벤트가 섞여 있을 수 있습니다. 이를 고려하여 producedAt의 date를 기준으로 먼저 grouping을 해준 뒤에 각각 product id 기준으로 groupping 해주었습니다. [RankingFacade.java:45](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-761aa568ed47e749f9aefccf3cc6302b6ef02befdc391a34a74506ce301ed327)

---

### 주문 완료 랭킹 스코어 반영 [RankingConsumer.java:24](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-b883e40547a13eb23a527503b7779505235ef3565c8ab57f943f382e8e684077)
 주문 완료 이벤트는 상대적으로 빈도수가 낮은 이벤트입니다. 또한 랭킹 스코어에 큰 영향을 미치는 이벤트입니다. 따라서 누락 없이, 멱등하게 처리되어야 합니다.

1. 배치 리스너 미사용
2. offset reset 방식 earliest
3. 멱등 처리 적용
4. product id 기준으로 groupping
5. redis zset에 score 반영 시 RTT 최소화를 위한 executePipelined 사용

---

### redis zset에 score 반영 시 RTT 최소화를 위한 executePipelined 사용 [ProductRankingRedisRepository.java:37](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-2b9dc0a9c408873a19ebbd0d7c1fe017002efb190e948b3338177317b4480c41)
 ZADD는 tuple로 가능하지만 기존 점수에 덮어쓰기 방식이라 increment에 이용하기 어렵습니다. 다른 방법을 찾아서 비교해봤습니다.

1. ZADD+ZUNIONSTORE+DEL 사용
- 증가 시킬 점수를 임시 ZSET에 ZADD 한 뒤 ZUNIONSTORE로 반영하고, 임시 ZSET을 DEL하는 방식입니다.
- ZUNIONSTORE가 기존 ZSET 전체를 재설정 하기 때문에 전체를 증감 시키는 경우에 적절해 보입니다.
3. 파이프라인 ZINCRBY
- executePipelined을 사용하여 ZINCRBY 명령들을 한번에 전송하고 한번에 응답 받는 방식입니다.
- RTT를 최소화하여 속도가 빠릅니다.

 product id로 파티션이 지정되고, product id로 groupping 까지 하고 있기 때문에 한번에 대상이 되는 product id의 수가 과도하게 많지는 않을 것입니다. 따라서 2번 방식으로 진행했습니다.

---

### score carry over [RankingScheduler.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-ee6a8b372e14e55f5ff9396685c57fa31ba61d279872ac8a8ee93d36749b04a8)
 날짜가 지나는 시점에 발생하는 콜드 스타트 문제를 해결하기 위해 score carry over 를 진행했습니다. 23시 50분에 스케줄러를 통해서 처리했습니다.

- score cap 0.1로 지정하고 최대 점수가 score cap이 되도록 기존 score에 연산을 수행했습니다.
- 이후 이 score들을 tuple로 만들어 다음날 key로 ZADD 연산으로 한번에 추가했습니다.
- TTL도 2일 뒤로 설정했습니다.

 초기에 작은 이벤트 하나에 랭킹이 크게 변동될 수 있습니다. 이를 막기 위해 score cap을 높게 지정하고, 초기에 추가해둔 carry over를 조금씩 차감하는 방법을 고민했었습니다. 그러나 이 방식은 일간 랭킹에 전날 데이터가 포함되어 있는 순간이 존재합니다. 이 순간에 의해 새로운 상품들이 높은 랭킹으로 올라가 노출되기 어려울 수 있습니다. 또한 랭킹 초기화 이후에 랭킹이 크게 변동하는 것은 일간 랭킹의 재미 요소 중 하나라고 생각할 수 있습니다. 따라서 score cap 을 조회 수 1로 얻는 스코어인 0.1로 지정하였습니다. [ProductRankingService.java:110](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-6274af47389fb7a29c85549ce5fc64d59c206c0285cb4fbbb0349c74ad8df395)

---

### 스코어 가중치 결정 [ProductRankingService.java:16](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-6274af47389fb7a29c85549ce5fc64d59c206c0285cb4fbbb0349c74ad8df395)
- 조회 수 가중치 : 0.1 * count
- 좋아요 가중치 : 1.0 * count
- 구매 가중치 : 0.01 * price * amount

 조회 수, 좋아요는 이벤트당 1씩 count가 발생합니다. 구매는 price * amount가 상대적으로 매우 큰 값입니다. 따라서 10000원 사용 == 100 좋아요 == 1000 조회 수 비율로 영향을 줄 수 있도록 가중치를 결정했습니다.

---

### 가격 차이에서 발생하는 스코어 영향력 차이 줄이기 [ProductRankingService.java:38](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-6274af47389fb7a29c85549ce5fc64d59c206c0285cb4fbbb0349c74ad8df395)
 가격 차이에 따라 스코어 차이가 발생하는 것은 맞다고 생각합니다. 하지만 가격이 그대로 전부 반영되면 구매라는 행위에 대한 스코어가 무시되는 것 처럼 느껴졌습니다. 거듭제곱 가격 변환으로 가격 차이에 따른 영향력 차이를 조금 완만하게 만들었습니다.

- 기준 가격 : 50,000원
- 가격 알파값 : 0.80

 위 기준으로 가격에 연산을 한 결과 아래와 같은 보정이 적용되었습니다.

- 1,000원 → 2,187원
- 10,000원 → 13,797원
- 1,000,000원 → 549,280원

 이런 연산을 수행하는 메서드는 자세한 설명이 필수라고 생각합니다. 따라서 주석을 통해 상세하게 설명을 첨부해뒀습니다. [ProductRankingService.java:45](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-6274af47389fb7a29c85549ce5fc64d59c206c0285cb4fbbb0349c74ad8df395)

---

### 실시간 weight 조절 [RankingWeight.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-c6aebc7ce22d03498e8a695e3c95abb8d4793a9f8115eba64c3e289101e8226b)
 실시간 weight 조절이 가능하도록 DB에 weight을 저장하였습니다. DB 조회 부하를 좀 줄여주기 위해 Redis에 weight를 캐시하여 DB read 부하를 줄였습니다. weight 캐시는 TTL을 당일로 설정해서 DB에 새로운 weight이 설정되면 다음날 집계부터 반영될 수 있도록 했습니다. [RankingWeightRedisRepository.java](https://github.com/Loopers-Team-6/hainho/pull/25/files#diff-e09a0c12879696ce5f29ed1f0adffce1e6756797e1691f3d7387f2692c03e043)

 weight를 변경한다는 것은 서비스에 맞는 weight을 찾기 위해 실험을 진행한다는 것입니다. 효율적인 실험을 위해서는 실험 내역들이 모두 기록되어 있어야합니다. 따라서 DB에 영속화하는 것은 필수라고 생각합니다.

 weight을 수정하면 다음날 집계부터 반영된다는 룰을 설정했습니다. 따라서 캐시 만료 시간이 당일로 고정되어 있습니다. 이런 케이스는 LocalCache를 사용하기에 좋은 케이스라는 생각이 들었습니다.

---

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 📈 Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

### Additionals
- [x] **실시간 Weight 조절**
- [ ] **시간 랭킹**
- [x] **콜드 스타트 완화를 위한 Scheduler 구현**

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->