### PR TITLE
주간, 월간 집계 배치 구현

### DIFF
--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,7 +1,5 @@
 dependencies {
     // add-ons
-    implementation(project(":apps:commerce-api"))
-    implementation(project(":apps:commerce-streamer"))
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
     implementation(project(":modules:kafka"))
@@ -13,14 +11,16 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+    // batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    testImplementation("org.springframework.batch:spring-batch-test")
+
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
     // test-fixtures
-    testImplementation(testFixtures(project(":apps:commerce-api")))
-    testImplementation(testFixtures(project(":apps:commerce-streamer")))
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
     testImplementation(testFixtures(project(":modules:kafka")))

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,27 @@
+dependencies {
+    // add-ons
+    implementation(project(":apps:commerce-api"))
+    implementation(project(":apps:commerce-streamer"))
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":apps:commerce-api")))
+    testImplementation(testFixtures(project(":apps:commerce-streamer")))
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,22 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class CommerceBatchApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceBatchApplication.class, args);
+    }
+
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/MonthlyMetricsBatch.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/MonthlyMetricsBatch.java
@@ -1,0 +1,11 @@
+package com.loopers.application.metrics;
+
+public record MonthlyMetricsBatch(
+        Long productId,
+        Long monthNumber,
+        Long totalViews,
+        Long totalPurchases,
+        Long totalLikes,
+        Double averageScore
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyJobConfig.java
@@ -1,0 +1,43 @@
+package com.loopers.application.metrics;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+
+@Configuration
+public class ProductMetricMonthlyJobConfig {
+    public static final String TRIGGER_NAME = "ProductMetricMonthlyTrigger";
+    public static final String CRON_EXPRESSION = "0 0 0 1 * ?"; // Every 1st day of month at midnight
+    private static final String JOB_NAME = "ProductMetricMonthlyJob";
+    private static final Integer CHUNK_SIZE = 1000;
+
+    @Bean
+    public Job productMetricMonthlyJob(JobRepository jobRepository, Step productMetricMonthlyStep) {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(productMetricMonthlyStep)
+                .build();
+    }
+
+    @Bean
+    public Step productMetricMonthlyStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ProductMetricMonthlyReader reader,
+            ProductMetricMonthlyWriter writer
+    ) {
+        return new StepBuilder("ProductMetricMonthlyStep", jobRepository)
+                .<List<ProductMetricsMonthlyAggregation>, List<ProductMetricsMonthlyAggregation>>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyReader.java
@@ -1,0 +1,70 @@
+package com.loopers.application.metrics;
+
+import com.loopers.infrastructure.metrics.ProductMetricsWeeklyJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.util.List;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ProductMetricMonthlyReader implements ItemReader<List<ProductMetricsMonthlyAggregation>> {
+
+    private final ProductMetricsWeeklyJpaRepository weeklyRepository;
+
+    @Value("#{jobParameters['targetDate'] ?: T(java.time.LocalDate).now().toString()}")
+    private String targetDateStr;
+
+    @Value("${batch.chunk-size:1000}")
+    private int chunkSize;
+
+    private List<Long> productIds;
+    private int currentIndex = 0;
+    private boolean initialized = false;
+
+    @Override
+    public List<ProductMetricsMonthlyAggregation> read() throws Exception {
+        if (!initialized) {
+            initializeProductIds();
+            initialized = true;
+        }
+
+        if (currentIndex >= productIds.size()) {
+            return null; // End of data
+        }
+
+        int endIndex = Math.min(currentIndex + chunkSize, productIds.size());
+        List<Long> chunkProductIds = productIds.subList(currentIndex, endIndex);
+        currentIndex = endIndex;
+
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        YearMonth targetMonth = YearMonth.from(targetDate);
+        LocalDate monthStart = targetMonth.atDay(1);
+        LocalDate monthEnd = targetMonth.atEndOfMonth();
+
+        Long startWeek = (long) monthStart.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+        Long endWeek = (long) monthEnd.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+
+        return weeklyRepository.findAggregatedMonthlyByProductIds(chunkProductIds, startWeek, endWeek);
+    }
+
+    private void initializeProductIds() {
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        YearMonth targetMonth = YearMonth.from(targetDate);
+        LocalDate monthStart = targetMonth.atDay(1);
+        LocalDate monthEnd = targetMonth.atEndOfMonth();
+
+        Long startWeek = (long) monthStart.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+        Long endWeek = (long) monthEnd.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+
+        this.productIds = weeklyRepository.findDistinctProductIds(startWeek, endWeek);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricMonthlyWriter.java
@@ -1,0 +1,46 @@
+package com.loopers.application.metrics;
+
+import com.loopers.infrastructure.metrics.ProductMetricsMonthlyRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ProductMetricMonthlyWriter implements ItemWriter<List<ProductMetricsMonthlyAggregation>> {
+
+    private final ProductMetricsMonthlyRepositoryImpl repository;
+
+    @Value("#{jobParameters['targetDate'] ?: T(java.time.LocalDate).now().toString()}")
+    private String targetDateStr;
+
+    @Override
+    public void write(Chunk<? extends List<ProductMetricsMonthlyAggregation>> chunk) throws Exception {
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        YearMonth targetMonth = YearMonth.from(targetDate);
+        long monthNumber = targetMonth.getMonthValue();
+
+        List<MonthlyMetricsBatch> batchData = chunk.getItems().stream()
+                .flatMap(List::stream)
+                .map(aggregation -> new MonthlyMetricsBatch(
+                        aggregation.productId(),
+                        monthNumber,
+                        aggregation.totalViews(),
+                        aggregation.totalPurchases(),
+                        aggregation.totalLikes(),
+                        aggregation.calculateScore()
+                ))
+                .toList();
+
+        repository.bulkUpsertWithIncrement(batchData);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyJobConfig.java
@@ -1,0 +1,44 @@
+package com.loopers.application.metrics;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+
+@Configuration
+public class ProductMetricWeeklyJobConfig {
+    public static final String TRIGGER_NAME = "ProductMetricWeeklyTrigger";
+    public static final String CRON_EXPRESSION = "0 0 0 ? * MON"; // Every Monday at midnight
+    private static final String JOB_NAME = "ProductMetricWeeklyJob";
+    private static final Integer CHUNK_SIZE = 1000;
+
+    @Bean
+    public Job productMetricWeeklyJob(JobRepository jobRepository, Step productMetricWeeklyStep) {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(productMetricWeeklyStep)
+                .build();
+    }
+
+    @Bean
+    public Step productMetricWeeklyStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ProductMetricWeeklyReader reader,
+            ProductMetricWeeklyWriter writer
+    ) {
+        return new StepBuilder("ProductMetricWeeklyStep", jobRepository)
+                .<List<ProductMetricsWeeklyAggregation>, List<ProductMetricsWeeklyAggregation>>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyReader.java
@@ -1,0 +1,62 @@
+package com.loopers.application.metrics;
+
+import com.loopers.infrastructure.metrics.ProductMetricsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ProductMetricWeeklyReader implements ItemReader<List<ProductMetricsWeeklyAggregation>> {
+
+    private final ProductMetricsJpaRepository repository;
+
+    @Value("#{jobParameters['targetDate'] ?: T(java.time.LocalDate).now().toString()}")
+    private String targetDateStr;
+
+    @Value("${batch.chunk-size:1000}")
+    private int chunkSize;
+
+    private List<Long> productIds;
+    private int currentIndex = 0;
+    private boolean initialized = false;
+
+    @Override
+    public List<ProductMetricsWeeklyAggregation> read() throws Exception {
+        if (!initialized) {
+            initializeProductIds();
+            initialized = true;
+        }
+
+        if (currentIndex >= productIds.size()) {
+            return null; // End of data
+        }
+
+        int endIndex = Math.min(currentIndex + chunkSize, productIds.size());
+        List<Long> chunkProductIds = productIds.subList(currentIndex, endIndex);
+        currentIndex = endIndex;
+
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDate weekStart = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        return repository.findAggregatedByProductIds(chunkProductIds, weekStart, weekEnd);
+    }
+
+    private void initializeProductIds() {
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDate weekStart = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        this.productIds = repository.findDistinctProductIds(weekStart, weekEnd);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricWeeklyWriter.java
@@ -1,0 +1,48 @@
+package com.loopers.application.metrics;
+
+import com.loopers.infrastructure.metrics.ProductMetricsWeeklyRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ProductMetricWeeklyWriter implements ItemWriter<List<ProductMetricsWeeklyAggregation>> {
+
+    private final ProductMetricsWeeklyRepositoryImpl repository;
+
+    @Value("#{jobParameters['targetDate'] ?: T(java.time.LocalDate).now().toString()}")
+    private String targetDateStr;
+
+    @Override
+    public void write(Chunk<? extends List<ProductMetricsWeeklyAggregation>> chunk) throws Exception {
+        LocalDate targetDate = LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDate weekStart = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        long weekNumber = weekStart.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
+
+        List<WeeklyMetricsBatch> batchData = chunk.getItems().stream()
+                .flatMap(List::stream)
+                .map(aggregation -> new WeeklyMetricsBatch(
+                        aggregation.productId(),
+                        weekNumber,
+                        aggregation.views(),
+                        aggregation.purchases(),
+                        aggregation.likes(),
+                        aggregation.calculateScore()
+                ))
+                .toList();
+
+        repository.bulkUpsertWithIncrement(batchData);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsGroup.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsGroup.java
@@ -1,0 +1,11 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+
+import java.util.List;
+
+public record ProductMetricsGroup(
+        Long productId,
+        List<ProductMetrics> dailyMetrics
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsMonthlyAggregation.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsMonthlyAggregation.java
@@ -1,0 +1,16 @@
+package com.loopers.application.metrics;
+
+public record ProductMetricsMonthlyAggregation(
+        Long productId,
+        Long totalViews,
+        Long totalPurchases,
+        Long totalLikes,
+        Double averageScore
+) {
+    public Double calculateScore() {
+        if (totalViews == 0) return 0.0;
+        double purchaseRate = (double) totalPurchases / totalViews;
+        double likeRate = (double) totalLikes / totalViews;
+        return purchaseRate * 0.7 + likeRate * 0.3;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsWeeklyAggregation.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/ProductMetricsWeeklyAggregation.java
@@ -1,0 +1,12 @@
+package com.loopers.application.metrics;
+
+public record ProductMetricsWeeklyAggregation(
+        Long productId,
+        Long views,
+        Long purchases,
+        Long likes
+) {
+    public double calculateScore() {
+        return (purchases * 10.0) + (likes * 2.0) + (views * 0.1);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/metrics/WeeklyMetricsBatch.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/metrics/WeeklyMetricsBatch.java
@@ -1,0 +1,11 @@
+package com.loopers.application.metrics;
+
+public record WeeklyMetricsBatch(
+        Long productId,
+        Long weekNumber,
+        Long views,
+        Long purchases,
+        Long likes,
+        Double score
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "product_metrics",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_product_metrics_product_id_measured_date",
+                        columnNames = {"productId", "measured_date"}
+                )
+        }
+)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class ProductMetrics extends BaseEntity {
+    private Long productId;
+    private Long views;
+    private Long purchases;
+    private Long likes;
+    private LocalDate measuredDate;
+
+    public static ProductMetrics of(Long productId, Long views, Long purchases, Long likes, LocalDate measuredDate) {
+        ProductMetrics productMetrics = new ProductMetrics();
+        productMetrics.productId = productId;
+        productMetrics.views = views;
+        productMetrics.purchases = purchases;
+        productMetrics.likes = likes;
+        productMetrics.measuredDate = measuredDate;
+        return productMetrics;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsMonthly.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsMonthly.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "product_metrics_monthly",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_product_metrics_monthly_product_id_measured_month",
+                        columnNames = {"productId", "measured_month"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductMetricsMonthly extends BaseEntity {
+    private Long productId;
+    private Long views;
+    private Long purchases;
+    private Long likes;
+    private Double score;
+    private Long measuredMonth;
+
+    private ProductMetricsMonthly(Long productId, Long views, Long purchases, Long likes, Double score, Long measuredMonth) {
+        this.productId = productId;
+        this.views = views;
+        this.purchases = purchases;
+        this.likes = likes;
+        this.score = score;
+        this.measuredMonth = measuredMonth;
+    }
+
+    public static ProductMetricsMonthly of(Long productId, Long views, Long purchases, Long likes, Double score, Long measuredMonth) {
+        return new ProductMetricsMonthly(productId, views, purchases, likes, score, measuredMonth);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsMonthlyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsMonthlyRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.metrics;
+
+public interface ProductMetricsMonthlyRepository {
+    ProductMetricsMonthly save(ProductMetricsMonthly metrics);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsWeekly.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsWeekly.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "product_metrics_weekly",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_product_metrics_weekly_product_id_measured_week",
+                        columnNames = {"productId", "measured_week"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductMetricsWeekly extends BaseEntity {
+    private Long productId;
+    private Long views;
+    private Long purchases;
+    private Long likes;
+    private Double score;
+    private Long measuredWeek;
+
+    private ProductMetricsWeekly(Long productId, Long views, Long purchases, Long likes, Double score, Long measuredWeek) {
+        this.productId = productId;
+        this.views = views;
+        this.purchases = purchases;
+        this.likes = likes;
+        this.score = score;
+        this.measuredWeek = measuredWeek;
+    }
+
+    public static ProductMetricsWeekly of(Long productId, Long views, Long purchases, Long likes, Double score, Long measuredWeek) {
+        return new ProductMetricsWeekly(productId, views, purchases, likes, score, measuredWeek);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsWeeklyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsWeeklyRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.metrics;
+
+public interface ProductMetricsWeeklyRepository {
+    ProductMetricsWeekly save(ProductMetricsWeekly metrics);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.application.metrics.ProductMetricsWeeklyAggregation;
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+    List<ProductMetrics> findByMeasuredDateBetween(LocalDate startDate, LocalDate endDate);
+
+    Page<ProductMetrics> findByMeasuredDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);
+
+    @Query("SELECT DISTINCT p.productId FROM ProductMetrics p WHERE p.measuredDate BETWEEN :startDate AND :endDate ORDER BY p.productId")
+    List<Long> findDistinctProductIds(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("""
+            SELECT new com.loopers.application.metrics.ProductMetricsWeeklyAggregation(
+                p.productId,
+                SUM(p.views),
+                SUM(p.purchases),
+                SUM(p.likes)
+            )
+            FROM ProductMetrics p
+            WHERE p.productId IN :productIds AND p.measuredDate BETWEEN :startDate AND :endDate
+            GROUP BY p.productId
+            ORDER BY p.productId
+            """)
+    List<ProductMetricsWeeklyAggregation> findAggregatedByProductIds(
+            @Param("productIds") List<Long> productIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsMonthlyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsMonthlyJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetricsMonthly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsMonthlyJpaRepository extends JpaRepository<ProductMetricsMonthly, Long> {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsMonthlyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsMonthlyRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetricsMonthly;
+import com.loopers.domain.metrics.ProductMetricsMonthlyRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductMetricsMonthlyRepositoryImpl implements ProductMetricsMonthlyRepository {
+    private final ProductMetricsMonthlyJpaRepository jpaRepository;
+
+    @Override
+    public ProductMetricsMonthly save(ProductMetricsMonthly metrics) {
+        return jpaRepository.save(metrics);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetricsWeekly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsWeeklyJpaRepository extends JpaRepository<ProductMetricsWeekly, Long> {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyJpaRepository.java
@@ -1,7 +1,80 @@
 package com.loopers.infrastructure.metrics;
 
+import com.loopers.application.metrics.ProductMetricsMonthlyAggregation;
 import com.loopers.domain.metrics.ProductMetricsWeekly;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProductMetricsWeeklyJpaRepository extends JpaRepository<ProductMetricsWeekly, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            INSERT INTO product_metrics_weekly
+                (product_id, measured_week, views, purchases, likes, score, created_at, updated_at)
+            VALUES
+                (:productId, :measuredWeek, :views, :purchases, :likes, :score, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                views      = views      + :views,
+                purchases  = purchases  + :purchases,
+                likes      = likes      + :likes,
+                score      = (purchases + :purchases) * 10.0 + (likes + :likes) * 2.0 + (views + :views) * 0.1,
+                updated_at = NOW()
+            """, nativeQuery = true)
+    int upsertWeeklyMetrics(
+            @Param("productId") Long productId,
+            @Param("measuredWeek") Long measuredWeek,
+            @Param("views") Long views,
+            @Param("purchases") Long purchases,
+            @Param("likes") Long likes,
+            @Param("score") Double score
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            INSERT INTO product_metrics_weekly
+                (product_id, measured_week, views, purchases, likes, score, created_at, updated_at)
+            VALUES :valuesClause
+            ON DUPLICATE KEY UPDATE
+                views      = views      + VALUES(views),
+                purchases  = purchases  + VALUES(purchases),
+                likes      = likes      + VALUES(likes),
+                score      = (purchases + VALUES(purchases)) * 10.0 + (likes + VALUES(likes)) * 2.0 + (views + VALUES(views)) * 0.1,
+                updated_at = NOW()
+            """, nativeQuery = true)
+    int bulkUpsertWeeklyMetrics(@Param("valuesClause") String valuesClause);
+
+    @Query("""
+            SELECT new com.loopers.application.metrics.ProductMetricsMonthlyAggregation(
+                pmw.productId,
+                SUM(pmw.views),
+                SUM(pmw.purchases),
+                SUM(pmw.likes),
+                AVG(pmw.score)
+            )
+            FROM ProductMetricsWeekly pmw
+            WHERE pmw.productId IN :productIds
+              AND pmw.measuredWeek >= :startWeek
+              AND pmw.measuredWeek <= :endWeek
+            GROUP BY pmw.productId
+            """)
+    List<ProductMetricsMonthlyAggregation> findAggregatedMonthlyByProductIds(
+            @Param("productIds") List<Long> productIds,
+            @Param("startWeek") Long startWeek,
+            @Param("endWeek") Long endWeek
+    );
+
+    @Query("""
+            SELECT DISTINCT pmw.productId
+            FROM ProductMetricsWeekly pmw
+            WHERE pmw.measuredWeek >= :startWeek
+              AND pmw.measuredWeek <= :endWeek
+            """)
+    List<Long> findDistinctProductIds(
+            @Param("startWeek") Long startWeek,
+            @Param("endWeek") Long endWeek
+    );
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyRepositoryImpl.java
@@ -4,15 +4,46 @@ import com.loopers.domain.metrics.ProductMetricsWeekly;
 import com.loopers.domain.metrics.ProductMetricsWeeklyRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductMetricsWeeklyRepositoryImpl implements ProductMetricsWeeklyRepository {
     private final ProductMetricsWeeklyJpaRepository jpaRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public ProductMetricsWeekly save(ProductMetricsWeekly metrics) {
         return jpaRepository.save(metrics);
+    }
+
+    public void bulkUpsertWithIncrement(List<com.loopers.application.metrics.WeeklyMetricsBatch> batchData) {
+        List<Object[]> batchArgs = batchData.stream()
+                .map(data -> new Object[]{
+                        data.productId(),
+                        data.weekNumber(),
+                        data.views(),
+                        data.purchases(),
+                        data.likes(),
+                        data.score()
+                })
+                .toList();
+
+        String sql = """
+                INSERT INTO product_metrics_weekly
+                    (product_id, measured_week, views, purchases, likes, score, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
+                ON DUPLICATE KEY UPDATE
+                    views      = views      + VALUES(views),
+                    purchases  = purchases  + VALUES(purchases),
+                    likes      = likes      + VALUES(likes),
+                    score      = (purchases + VALUES(purchases)) * 10.0 + (likes + VALUES(likes)) * 2.0 + (views + VALUES(views)) * 0.1,
+                    updated_at = NOW()
+                """;
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsWeeklyRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetricsWeekly;
+import com.loopers.domain.metrics.ProductMetricsWeeklyRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductMetricsWeeklyRepositoryImpl implements ProductMetricsWeeklyRepository {
+    private final ProductMetricsWeeklyJpaRepository jpaRepository;
+
+    @Override
+    public ProductMetricsWeekly save(ProductMetricsWeekly metrics) {
+        return jpaRepository.save(metrics);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/spring/metrics/MonthlyMetricsScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/spring/metrics/MonthlyMetricsScheduler.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.spring.metrics;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+public class MonthlyMetricsScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job productMetricMonthlyJob;
+
+    public MonthlyMetricsScheduler(JobLauncher jobLauncher,
+                                   @Qualifier("productMetricMonthlyJob") Job productMetricMonthlyJob) {
+        this.jobLauncher = jobLauncher;
+        this.productMetricMonthlyJob = productMetricMonthlyJob;
+    }
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void runMonthlyMetricsBatch() {
+        try {
+            LocalDate targetDate = LocalDate.now().minusMonths(1);
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate", targetDate.toString())
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            log.info("Starting monthly metrics batch for date: {}", targetDate);
+            jobLauncher.run(productMetricMonthlyJob, jobParameters);
+            log.info("Monthly metrics batch completed successfully");
+
+        } catch (Exception e) {
+            log.error("Failed to run monthly metrics batch", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/spring/metrics/WeeklyMetricsScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/spring/metrics/WeeklyMetricsScheduler.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.spring.metrics;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+public class WeeklyMetricsScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job productMetricWeeklyJob;
+
+    public WeeklyMetricsScheduler(JobLauncher jobLauncher,
+                                  @Qualifier("productMetricWeeklyJob") Job productMetricWeeklyJob) {
+        this.jobLauncher = jobLauncher;
+        this.productMetricWeeklyJob = productMetricWeeklyJob;
+    }
+
+    @Scheduled(cron = "0 0 0 ? * MON")
+    public void runWeeklyMetricsBatch() {
+        try {
+            LocalDate targetDate = LocalDate.now().minusDays(7);
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate", targetDate.toString())
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            log.info("Starting weekly metrics batch for date: {}", targetDate);
+            jobLauncher.run(productMetricWeeklyJob, jobParameters);
+            log.info("Weekly metrics batch completed successfully");
+
+        } catch (Exception e) {
+            log.error("Failed to run weekly metrics batch", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -25,6 +25,11 @@ spring:
       - kafka.yml
       - logging.yml
       - monitoring.yml
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
 
 springdoc:
   use-fqn: true

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,66 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+  port: 8084
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - kafka.yml
+      - logging.yml
+      - monitoring.yml
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus"
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -28,4 +29,6 @@ public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetric
             @Param("purchasesDelta") long purchasesDelta,
             @Param("likesDelta") long likesDelta
     );
+
+    List<ProductMetrics> findByMeasuredDateBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "loopers-java-spring-template"
 
 include(
     ":apps:commerce-api",
+    ":apps:commerce-batch",
     ":apps:commerce-streamer",
     ":apps:pg-simulator",
     ":modules:jpa",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

### 주간 집계 배치 chunk 방식
 `chunk 조회 쿼리, 데이터 조회 쿼리, 데이터 업데이트 쿼리` 모두 효율적으로 하고 싶었습니다. 데이터 조회 쿼리는 groupby, sum으로 일주일치를 합산하여 product id를 기준으로 chunk size 만큼 읽어오는 것이 효율적이라 생각됩니다. 데이터 업데이트 쿼리는 한번에 벌크 인서트가 가장 효율적이라 생각됩니다.

 여기서 chunk를 page 기반으로 수행하게 되면 2가지 문제가 발생하게 됩니다.

1. page 기반이라 no offset 보다 비효율적
2. groupby 에 대해 page 처리를 하기 때문에 매 쿼리마다 현재 대상 product id 뿐만 아니라 일주일치 일간 metrics 전체에 대해 groupby가 수행된다.

 그래서 저는 이 두가지를 막기 위해서 chunk 기준이 되는 일주일치 일간 metrics를 미리 groupby, distinct로 product id만 가져왔습니다. 이후 product id를 chunk로 잘라서 사용했고, 조회 쿼리는 where in 조건으로 해당 product id들을 포함할 수 있도록 했습니다.

 이렇게 하면 매 조회 쿼리마다 전체 groupby를 하지 않아도 되어 효율적인 방법이라 생각됩니다.

 혹시 이 방법에 대해서 멘토님은 어떻게 생각하시는지, 다른 좋은 방법은 없나 궁금합니다!

 아 그리고 이런 상황에서는 확실히 reader 에 맞추는 것보다는 tasklet이 편할 것 같기도 하네요...!!

---

### 집계 배치에서 groupby, sum
 집계 배치에서 groupby, sum 쿼리로 합계 연산을 수행했는데요. 이렇게 DB에 합계 연산 부하를 넘기는 대신 일주일치를 그냥 조회하고, 애플리케이션에서 sum하여 합계 연산 부하를 애플리케이션으로 넘길 수도 있을 것 같습니다. 대신 읽어오는 데이터가 많아지는 문제도 있겠지만요.

 application이 scale out에 용이하여 DB 부하보다는 application 부하로 처리를 하고 싶은데, 이 상황에서는 읽어오는 데이터가 많아져 결국 또 다른 부하가 발생하는 상황이라 DB 부하를 주는 groupby, sum 쿼리를 사용했습니다.

 이러한 케이스에서 어떤 선택이 더 좋은 선택인지 고민됩니다. 이런 상황에서 합리적인 선택을 하려면 직접 성능을 측정해보고 결정하는 것이 좋을까요?

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->